### PR TITLE
Add `wandb` logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,9 +87,6 @@ instance/
 # Scrapy stuff:
 .scrapy
 
-# Sphinx documentation
-docs/_build/
-
 # PyBuilder
 .pybuilder/
 target/
@@ -161,6 +158,12 @@ cython_debug/
 docs/source/generated
 docs/source/api
 docs/source/models
+docs/build/
+docs/source/_build/
 
 # Misc
 .DS_Store
+
+# logs
+wandb/
+lightning_logs/

--- a/anomalib/core/callbacks/visualizer_callback.py
+++ b/anomalib/core/callbacks/visualizer_callback.py
@@ -11,6 +11,7 @@ from skimage.segmentation import mark_boundaries
 from anomalib import loggers
 from anomalib.core.model import AnomalyModule
 from anomalib.data.transforms import Denormalize
+from anomalib.loggers.wandb import AnomalibWandbLogger
 from anomalib.utils.post_process import compute_mask, superimpose_anomaly_map
 from anomalib.utils.visualizer import Visualizer
 
@@ -98,3 +99,15 @@ class VisualizerCallback(Callback):
             visualizer.add_image(image=vis_img, title="Segmentation Result")
             self._add_images(visualizer, pl_module, Path(filename))
             visualizer.close()
+
+    def on_test_end(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
+        """Sync logs.
+
+        Some loggers prefer syncing the batch at the end rather than logging at each timestep.
+
+        Args:
+            trainer (pl.Trainer): Pytorch Lightning trainer
+            pl_module (pl.LightningModule): Anomaly module
+        """
+        if pl_module.logger is not None and isinstance(pl_module.logger, AnomalibWandbLogger):
+            pl_module.logger.save()

--- a/anomalib/core/callbacks/visualizer_callback.py
+++ b/anomalib/core/callbacks/visualizer_callback.py
@@ -103,7 +103,8 @@ class VisualizerCallback(Callback):
     def on_test_end(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
         """Sync logs.
 
-        Some loggers prefer syncing the batch at the end rather than logging at each timestep.
+        Currently only ``AnomalibWandbLogger`` is called from this method. This is because logging as a single batch
+        ensures that all images appear as part of the same step.
 
         Args:
             trainer (pl.Trainer): Pytorch Lightning trainer

--- a/anomalib/loggers/__init__.py
+++ b/anomalib/loggers/__init__.py
@@ -23,9 +23,10 @@ from omegaconf.listconfig import ListConfig
 from pytorch_lightning.loggers.base import LightningLoggerBase
 
 from .tensorboard import AnomalibTensorBoardLogger
+from .wandb import AnomalibWandbLogger
 
-__all__ = ["AnomalibTensorBoardLogger", "get_logger"]
-AVAILABLE_LOGGERS = ["tensorboard"]
+__all__ = ["AnomalibTensorBoardLogger", "get_logger", "AnomalibWandbLogger"]
+AVAILABLE_LOGGERS = ["tensorboard", "wandb"]
 
 
 class UnknownLogger(Exception):
@@ -53,6 +54,15 @@ def get_logger(config: Union[DictConfig, ListConfig]) -> Union[LightningLoggerBa
         logger = AnomalibTensorBoardLogger(
             name="Tensorboard Logs",
             save_dir=os.path.join(config.project.path, "logs"),
+        )
+
+    elif config.project.logger == "wandb":
+        wandb_logdir = os.path.join(config.project.path, "logs")
+        os.makedirs(wandb_logdir, exist_ok=True)
+        logger = AnomalibWandbLogger(
+            project=config.dataset.name,
+            name=f"{config.dataset.category} {config.model.name}",
+            save_dir=wandb_logdir,
         )
 
     else:

--- a/anomalib/loggers/tensorboard.py
+++ b/anomalib/loggers/tensorboard.py
@@ -28,16 +28,18 @@ class AnomalibTensorBoardLogger(ImageLoggerBase, TensorBoardLogger):
     """Logger for tensorboard.
 
     Adds interface for `add_image` in the logger rather than calling the experiment object.
-    The rest is same as the Tensorboard Logger provided by PyTorch Lightning and the doc string
-    for which is reproduced below
+
+    Note:
+        Same as the Tensorboard Logger provided by PyTorch Lightning and the doc string is reproduced below.
+
     Logs are saved to
     ``os.path.join(save_dir, name, version)``. This is the default logger in Lightning, it comes
     preinstalled.
 
     Example:
         >>> from pytorch_lightning import Trainer
-        >>> from pytorch_lightning.loggers import TensorBoardLogger
-        >>> logger = TensorBoardLogger("tb_logs", name="my_model")
+        >>> from anomalib.loggers.tensorboard import AnomalibTensorBoardLogger
+        >>> logger = AnomalibTensorBoardLogger("tb_logs", name="my_model")
         >>> trainer = Trainer(logger=logger)
 
     Args:

--- a/anomalib/loggers/tensorboard.py
+++ b/anomalib/loggers/tensorboard.py
@@ -29,7 +29,7 @@ class AnomalibTensorBoardLogger(ImageLoggerBase, TensorBoardLogger):
 
     Adds interface for `add_image` in the logger rather than calling the experiment object.
     The rest is same as the Tensorboard Logger provided by PyTorch Lightning and the doc string
-    for which is reporduced below
+    for which is reproduced below
     Logs are saved to
     ``os.path.join(save_dir, name, version)``. This is the default logger in Lightning, it comes
     preinstalled.

--- a/anomalib/loggers/wandb.py
+++ b/anomalib/loggers/wandb.py
@@ -29,8 +29,9 @@ class AnomalibWandbLogger(ImageLoggerBase, WandbLogger):
     """Logger for wandb.
 
     Adds interface for `add_image` in the logger rather than calling the experiment object.
-    The rest is same as the WandbLogger provided by PyTorch Lightning and the doc string
-    for which is reproduced below:
+
+    Note:
+        Same as the wandb Logger provided by PyTorch Lightning and the doc string is reproduced below.
 
     Log using `Weights and Biases <https://www.wandb.com/>`_.
 
@@ -60,9 +61,9 @@ class AnomalibWandbLogger(ImageLoggerBase, WandbLogger):
             If both ``log_model`` and ``offline``is set to ``True``.
 
     Example:
-        >>> from pytorch_lightning.loggers import WandbLogger
+        >>> from anomalib.loggers.wandb import AnomalibWandbLogger
         >>> from pytorch_lightning import Trainer
-        >>> wandb_logger = WandbLogger()
+        >>> wandb_logger = AnomalibWandbLogger()
         >>> trainer = Trainer(logger=wandb_logger)
 
     Note: When logging manually through `wandb.log` or `trainer.logger.experiment.log`,

--- a/anomalib/loggers/wandb.py
+++ b/anomalib/loggers/wandb.py
@@ -1,0 +1,124 @@
+"""wandb logger with add image interface."""
+
+# Copyright (C) 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+from typing import Any, Optional, Union
+
+import numpy as np
+from matplotlib.figure import Figure
+from pytorch_lightning.loggers.wandb import WandbLogger
+from pytorch_lightning.utilities import rank_zero_only
+
+import wandb
+
+from .base import ImageLoggerBase
+
+
+class AnomalibWandbLogger(ImageLoggerBase, WandbLogger):
+    """Logger for wandb.
+
+    Adds interface for `add_image` in the logger rather than calling the experiment object.
+    The rest is same as the WandbLogger provided by PyTorch Lightning and the doc string
+    for which is reproduced below:
+
+    Log using `Weights and Biases <https://www.wandb.com/>`_.
+
+    Install it with pip:
+
+    .. code-block:: bash
+
+        $ pip install wandb
+
+    Args:
+        name: Display name for the run.
+        save_dir: Path where data is saved (wandb dir by default).
+        offline: Run offline (data can be streamed later to wandb servers).
+        id: Sets the version, mainly used to resume a previous run.
+        version: Same as id.
+        anonymous: Enables or explicitly disables anonymous logging.
+        project: The name of the project to which this run will belong.
+        log_model: Save checkpoints in wandb dir to upload on W&B servers.
+        prefix: A string to put at the beginning of metric keys.
+        experiment: WandB experiment object. Automatically set when creating a run.
+        **kwargs: Arguments passed to :func:`wandb.init` like `entity`, `group`, `tags`, etc.
+
+    Raises:
+        ImportError:
+            If required WandB package is not installed on the device.
+        MisconfigurationException:
+            If both ``log_model`` and ``offline``is set to ``True``.
+
+    Example:
+        >>> from pytorch_lightning.loggers import WandbLogger
+        >>> from pytorch_lightning import Trainer
+        >>> wandb_logger = WandbLogger()
+        >>> trainer = Trainer(logger=wandb_logger)
+
+    Note: When logging manually through `wandb.log` or `trainer.logger.experiment.log`,
+    make sure to use `commit=False` so the logging step does not increase.
+
+    See Also:
+        - `Tutorial <https://colab.research.google.com/drive/16d1uctGaw2y9KhGBlINNTsWpmlXdJwRW?usp=sharing>`__
+          on how to use W&B with PyTorch Lightning
+        - `W&B Documentation <https://docs.wandb.ai/integrations/lightning>`__
+
+    """
+
+    def __init__(
+        self,
+        name: Optional[str] = None,
+        save_dir: Optional[str] = None,
+        offline: Optional[bool] = False,
+        id: Optional[str] = None,  # kept to match wandb init pylint: disable=redefined-builtin
+        anonymous: Optional[bool] = None,
+        version: Optional[str] = None,
+        project: Optional[str] = None,
+        log_model: Optional[bool] = False,
+        experiment=None,
+        prefix: Optional[str] = "",
+        sync_step: Optional[bool] = None,
+        **kwargs
+    ) -> None:
+        super().__init__(
+            name=name,
+            save_dir=save_dir,
+            offline=offline,
+            id=id,
+            anonymous=anonymous,
+            version=version,
+            project=project,
+            log_model=log_model,
+            experiment=experiment,
+            prefix=prefix,
+            sync_step=sync_step,
+            **kwargs
+        )
+
+    @rank_zero_only
+    def add_image(self, image: Union[np.ndarray, Figure], name: Optional[str] = None, **kwargs: Any):
+        """Interface to add image to wandb logger.
+
+        Args:
+            image (Union[np.ndarray, Figure]): Image to log
+            name (Optional[str]): The tag of the image
+            kwargs: Accepts only `global_step` (int). The step at which to log the image.
+                If not provided, wandb will assume that each image is added at a different step.
+        """
+        step = None
+        if "global_step" in kwargs:
+            step = kwargs.get("global_step")
+
+        image = wandb.Image(image, caption=name)
+        wandb.log({"Predictions": image}, step=step)

--- a/anomalib/loggers/wandb.py
+++ b/anomalib/loggers/wandb.py
@@ -17,11 +17,10 @@
 from typing import Any, List, Optional, Union
 
 import numpy as np
+import wandb
 from matplotlib.figure import Figure
 from pytorch_lightning.loggers.wandb import WandbLogger
 from pytorch_lightning.utilities import rank_zero_only
-
-import wandb
 
 from .base import ImageLoggerBase
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -14,3 +14,4 @@ scikit-image>=0.17.2
 kornia==0.5.6
 lxml
 albumentations
+wandb

--- a/tests/loggers/test_get_logger.py
+++ b/tests/loggers/test_get_logger.py
@@ -16,6 +16,7 @@
 
 import pytest
 from omegaconf import OmegaConf
+from pytorch_lightning.loggers.wandb import WandbLogger
 
 from anomalib.loggers import AnomalibTensorBoardLogger, UnknownLogger, get_logger
 
@@ -42,6 +43,11 @@ def test_get_logger():
     config.project.logger = "tensorboard"
     logger = get_logger(config=config)
     assert isinstance(logger, AnomalibTensorBoardLogger)
+
+    # get wandb logger
+    config.project.logger = "wandb"
+    logger = get_logger(config=config)
+    assert isinstance(logger, WandbLogger)
 
     # raise unknown
     with pytest.raises(UnknownLogger):


### PR DESCRIPTION
# Changes

- Add `wandb` logger.

# Known issues

- The docstring in `AnomalibWandbLogger` module is copied from the pytorch lightning wandb logger module. This is because the anomalib one just adds two more functions.
- Another method was added to `visualizer_callback` so that we can log images to wandb in batch rather than sequentially at each `log` call. This is because if images are not provided in batches, they get logged at a different step. So we can't see all the images side by side on the dashboard. Batch operation ensures they are available side by side.