### PR TITLE
fix heatmap color scheme

### DIFF
--- a/anomalib/utils/post_process.py
+++ b/anomalib/utils/post_process.py
@@ -37,6 +37,7 @@ def anomaly_map_to_color_map(anomaly_map: np.ndarray, normalize: bool = True) ->
     anomaly_map = anomaly_map.astype(np.uint8)
 
     anomaly_map = cv2.applyColorMap(anomaly_map, cv2.COLORMAP_JET)
+    anomaly_map = cv2.cvtColor(anomaly_map, cv2.COLOR_BGR2RGB)
     return anomaly_map
 
 
@@ -64,7 +65,6 @@ def superimpose_anomaly_map(
 
     anomaly_map = anomaly_map_to_color_map(anomaly_map.squeeze(), normalize=normalize)
     superimposed_map = cv2.addWeighted(anomaly_map, alpha, image, (1 - alpha), gamma)
-    superimposed_map = cv2.cvtColor(superimposed_map, cv2.COLOR_BGR2RGB)
     return superimposed_map
 
 


### PR DESCRIPTION
Quick fix for the inverted anomaly heatmaps in OTE. Maybe we should include this in 0.2.3 to prevent an additional round of testing.