### PR TITLE
Change hardcoded dataset path to environ variable

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,6 +22,7 @@ jobs:
         run: tox -e black,isort,flake8,pylint,mypy,pydocstyle
       - name: Coverage
         run: |
+          export ANOMALIB_DATASET_PATH=/media/data1/datasets/MVTec
           export CUDA_VISIBLE_DEVICES=3
           tox -e coverage
       - name: Upload coverage result

--- a/tests/helpers/dataset.py
+++ b/tests/helpers/dataset.py
@@ -23,8 +23,7 @@ def get_dataset_path(path: Union[str, Path] = "./datasets/MVTec"):
     # when running locally
     path = str(path)
     if not os.path.isdir(path):
-        # when using docker image
-        path = "/tmp/anomalib/datasets/MVTec"
+        path = os.environ["ANOMALIB_DATASET_PATH"]
     return path
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -63,6 +63,7 @@ passenv = ftp_proxy
     HTTP_PROXY
     HTTPS_PROXY
     CUDA_VISIBLE_DEVICES
+    ANOMALIB_DATASET_PATH
 deps =
     coverage
     pytest


### PR DESCRIPTION
# Changes

- Use environment variable for dataset path. This will make the tests agnostic to the machine on which it is run on.
- The workflow file is changed to point to the dataset path on the server.