### PR TITLE
Replace `SupportIndex` with `int`

### DIFF
--- a/anomalib/data/tiler.py
+++ b/anomalib/data/tiler.py
@@ -16,7 +16,7 @@
 
 from itertools import product
 from math import ceil
-from typing import Optional, Sequence, SupportsIndex, Tuple, Union
+from typing import Optional, Sequence, Tuple, Union
 
 import torch
 import torchvision.transforms as T
@@ -161,7 +161,7 @@ class Tiler:
         stride: Union[int, Sequence],
         remove_border_count: int = 0,
         mode: str = "padding",
-        tile_count: SupportsIndex = 4,
+        tile_count: int = 4,
     ) -> None:
 
         self.tile_size_h, self.tile_size_w = self.__validate_size_type(tile_size)


### PR DESCRIPTION
# Description

- This PR replaces `SupportIndex` with `int`, which was an artifact from commits from long time ago.

- Fixes #72 

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes