### PR TITLE
Fix Mix Data type issue on inferencer

### DIFF
--- a/anomalib/deploy/inferencers/torch.py
+++ b/anomalib/deploy/inferencers/torch.py
@@ -138,7 +138,7 @@ class TorchInferencer(Inferencer):
             anomaly_map = predictions
             pred_score = anomaly_map.reshape(-1).max()
         else:
-            if isinstance(predictions[1],( Tensor)):
+            if isinstance(predictions[1], (Tensor)):
                 anomaly_map, pred_score = predictions
                 pred_score = pred_score.detach()
             else:

--- a/anomalib/deploy/inferencers/torch.py
+++ b/anomalib/deploy/inferencers/torch.py
@@ -138,6 +138,10 @@ class TorchInferencer(Inferencer):
             anomaly_map = predictions
             pred_score = anomaly_map.reshape(-1).max()
         else:
+            # NOTE: Patchcore `forward`` returns heatmap and score.
+            #   We need to add the following check to ensure the variables
+            #   are properly assigned. Without this check, the code
+            #   throws an error regarding type mismatch torch vs np.
             if isinstance(predictions[1], (Tensor)):
                 anomaly_map, pred_score = predictions
                 pred_score = pred_score.detach()

--- a/anomalib/deploy/inferencers/torch.py
+++ b/anomalib/deploy/inferencers/torch.py
@@ -138,8 +138,12 @@ class TorchInferencer(Inferencer):
             anomaly_map = predictions
             pred_score = anomaly_map.reshape(-1).max()
         else:
-            anomaly_map, pred_score = predictions
-            pred_score = pred_score.detach().cpu().numpy()
+            if isinstance(predictions[1],( Tensor)):
+                anomaly_map, pred_score = predictions
+                pred_score = pred_score.detach()
+            else:
+                anomaly_map, pred_score = predictions
+                pred_score = pred_score.detach().numpy()
 
         anomaly_map = anomaly_map.squeeze()
 

--- a/anomalib/models/cflow/README.md
+++ b/anomalib/models/cflow/README.md
@@ -47,4 +47,3 @@ All results gathered with seed `42`.
 ![Sample Result 2](../../../docs/source/images/cflow/results/1.png "Sample Result 2")
 
 ![Sample Result 3](../../../docs/source/images/cflow/results/2.png "Sample Result 3")
-


### PR DESCRIPTION
# Description

- As suggested by the community, this PR fixes the mixed data type issue reported in #67

```
patchcore inference:
File "d:\projects\anomalib\anomalib\utils\normalization\min_max.py", line 31, in normalize
normalized = ((targets - threshold) / (max_val - min_val)) + 0.5
TypeError: unsupported operand type(s) for -: 'numpy.ndarray' and 'Tensor'
```

- Fixes #67 

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes