### PR TITLE
Reorder AUC and Python version 3.7

### DIFF
--- a/anomalib/core/metrics/auroc.py
+++ b/anomalib/core/metrics/auroc.py
@@ -14,4 +14,4 @@ class AUROC(ROC):
             Value of the AUROC metric
         """
         fpr, tpr, _thresholds = super().compute()
-        return auc(fpr, tpr)
+        return auc(fpr, tpr, reorder=True)

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
     license="Copyright (c) Intel - All Rights Reserved. "
     'Licensed under the Apache License, Version 2.0 (the "License")'
     "See LICENSE file for more details.",
-    python_requires=">=3.8",
+    python_requires=">=3.7",
     packages=find_packages("."),
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS_REQUIRE,


### PR DESCRIPTION
https://github.com/openvinotoolkit/anomalib/blob/f1c8a6b553b82a8974ccc9fd27aa5f9b939d5917/anomalib/core/metrics/auroc.py#L17

throws a `ValueError`: `The 'x' tensor is neither increasing or decreasing. Try setting the reorder argument to 'True'.`
It happens for large datasets I guess with only little variance in some validation datapoints?

I set `reorder=True` to resolve the problem.

Also as the development branch is compatible to Python 3.7, it should also be possible to install the package und 3.7
https://github.com/openvinotoolkit/anomalib/issues/72