### PR TITLE
Reorder auc only when needed

### DIFF
--- a/anomalib/core/metrics/auroc.py
+++ b/anomalib/core/metrics/auroc.py
@@ -14,6 +14,9 @@ class AUROC(ROC):
         Returns:
             Value of the AUROC metric
         """
+        tpr: Tensor
+        fpr: Tensor
+
         fpr, tpr, _thresholds = super().compute()
         # TODO: use stable sort after upgrading to pytorch 1.9.x (https://github.com/openvinotoolkit/anomalib/issues/92)
         if not (torch.all(fpr.diff() <= 0) or torch.all(fpr.diff() >= 0)):

--- a/anomalib/core/metrics/auroc.py
+++ b/anomalib/core/metrics/auroc.py
@@ -15,6 +15,7 @@ class AUROC(ROC):
             Value of the AUROC metric
         """
         fpr, tpr, _thresholds = super().compute()
+        # TODO: use stable sort after upgrading to pytorch 1.9.x (https://github.com/openvinotoolkit/anomalib/issues/92)
         if not (torch.all(fpr.diff() <= 0) or torch.all(fpr.diff() >= 0)):
             return auc(fpr, tpr, reorder=True)  # only reorder if fpr is not increasing or decreasing
         return auc(fpr, tpr)

--- a/anomalib/core/metrics/auroc.py
+++ b/anomalib/core/metrics/auroc.py
@@ -1,4 +1,5 @@
 """Implementation of AUROC metric based on TorchMetrics."""
+import torch
 from torch import Tensor
 from torchmetrics import ROC
 from torchmetrics.functional import auc
@@ -14,4 +15,6 @@ class AUROC(ROC):
             Value of the AUROC metric
         """
         fpr, tpr, _thresholds = super().compute()
+        if not (torch.all(fpr.diff() <= 0) or torch.all(fpr.diff() >= 0)):
+            return auc(fpr, tpr, reorder=True)  # only reorder if fpr is not increasing or decreasing
         return auc(fpr, tpr)

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ envlist =
 
 [testenv:black]
 basepython = python3
-deps = black
+deps = black==20.8b1
 commands = black --check --diff anomalib -l 120
 
 [testenv:isort]


### PR DESCRIPTION
This PR adds reordering to the AUC computation, but applies it only when necessary (i.e. `tpr` is not increasing or decreasing). This prevents the situation where the `tpr` elements corresponding to duplicate values in the `fpr` array get reordered in an unpredictable manner due to unstable sorting, which in turn may lead to underestimation of the performance score (see my comment under [this PR](https://github.com/openvinotoolkit/anomalib/pull/90)).