### PR TITLE
🐞 Fix tensor detach and gpu count issues in benchmarking script

### DIFF
--- a/anomalib/utils/sweep/helpers/inference.py
+++ b/anomalib/utils/sweep/helpers/inference.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Dict, Iterable, List, Tuple, Union
 
 import numpy as np
+import torch
 from omegaconf import DictConfig, ListConfig
 from torch.utils.data import DataLoader
 
@@ -106,6 +107,7 @@ def get_torch_throughput(
     Returns:
         float: Inference throughput
     """
+    torch.set_grad_enabled(False)
     model.eval()
     inferencer = TorchInferencer(config, model)
     torch_dataloader = MockImageLoader(config.dataset.image_size, len(test_dataset))
@@ -118,6 +120,7 @@ def get_torch_throughput(
     inference_time = time.time() - start_time
     throughput = len(test_dataset) / inference_time
 
+    torch.set_grad_enabled(True)
     return throughput
 
 

--- a/tools/benchmarking/benchmark.py
+++ b/tools/benchmarking/benchmark.py
@@ -16,6 +16,7 @@
 
 
 import logging
+import math
 import multiprocessing
 import time
 from concurrent.futures import ProcessPoolExecutor, as_completed
@@ -136,12 +137,12 @@ def distribute_over_gpus():
         run_configs = list(get_run_config(sweep_config.grid_search))
         jobs = []
         for device_id, run_split in enumerate(
-            range(0, len(run_configs), len(run_configs) // torch.cuda.device_count())
+            range(0, len(run_configs), math.ceil(len(run_configs) / torch.cuda.device_count()))
         ):
             jobs.append(
                 executor.submit(
                     compute_on_gpu,
-                    run_configs[run_split : run_split + len(run_configs) // torch.cuda.device_count()],
+                    run_configs[run_split : run_split + math.ceil(len(run_configs) / torch.cuda.device_count())],
                     device_id + 1,
                     sweep_config.seed,
                     sweep_config.writer,


### PR DESCRIPTION
# Description

This is a quick fix to the following issues

- Even with model.eval(), the models returned predictions with `grad_required = True`
- Due to incorrect calculation of splits, greater number of GPUs were being assigned

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
