### PR TITLE
Return predicted masks in predict step

### DIFF
--- a/anomalib/models/components/base/anomaly_module.py
+++ b/anomalib/models/components/base/anomaly_module.py
@@ -95,6 +95,8 @@ class AnomalyModule(pl.LightningModule, ABC):
         outputs = self.validation_step(batch, batch_idx)
         self._post_process(outputs)
         outputs["pred_labels"] = outputs["pred_scores"] >= self.image_threshold.value
+        if "anomaly_maps" in outputs.keys():
+            outputs["pred_masks"] = outputs["anomaly_maps"] >= self.pixel_threshold.value
         return outputs
 
     def test_step(self, batch, _):  # pylint: disable=arguments-differ


### PR DESCRIPTION
# Description

- Returns predicted masks in the predict step, needed for OTE Segmentation.

## Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
