### PR TITLE
Fix/da/image size bug

### DIFF
--- a/anomalib/data/__init__.py
+++ b/anomalib/data/__init__.py
@@ -39,7 +39,7 @@ def get_datamodule(config: Union[DictConfig, ListConfig]) -> LightningDataModule
             # TODO: Remove config values. IAAALD-211
             root=config.dataset.path,
             category=config.dataset.category,
-            image_size=(config.dataset.image_size[0], config.dataset.image_size[0]),
+            image_size=(config.dataset.image_size[0], config.dataset.image_size[1]),
             train_batch_size=config.dataset.train_batch_size,
             test_batch_size=config.dataset.test_batch_size,
             num_workers=config.dataset.num_workers,

--- a/anomalib/deploy/inferencers/torch.py
+++ b/anomalib/deploy/inferencers/torch.py
@@ -154,7 +154,7 @@ class TorchInferencer(Inferencer):
         anomaly_map, pred_score = self._normalize(anomaly_map, pred_score, meta_data)
 
         if isinstance(anomaly_map, Tensor):
-            anomaly_map = anomaly_map.cpu().numpy()
+            anomaly_map = anomaly_map.detach().cpu().numpy()
 
         if "image_shape" in meta_data and anomaly_map.shape != meta_data["image_shape"]:
             anomaly_map = cv2.resize(anomaly_map, meta_data["image_shape"])

--- a/anomalib/models/padim/model.py
+++ b/anomalib/models/padim/model.py
@@ -82,7 +82,7 @@ class PadimModel(nn.Module):
 
         n_features = DIMS[backbone]["reduced_dims"]
         patches_dims = torch.tensor(input_size) / DIMS[backbone]["emb_scale"]
-        n_patches = patches_dims.prod().int().item()
+        n_patches = patches_dims.ceil().prod().int().item()
         self.gaussian = MultiVariateGaussian(n_features, n_patches)
 
         if apply_tiling:

--- a/tests/pre_merge/datasets/test_dataset.py
+++ b/tests/pre_merge/datasets/test_dataset.py
@@ -105,6 +105,8 @@ class TestToNumpy:
 
 
 class TestConfigToDataModule:
+    """Tests that check if the dataset parameters in the config achieve the desired effect."""
+
     @pytest.mark.parametrize(
         ["input_size", "effective_image_size"],
         [
@@ -115,6 +117,7 @@ class TestConfigToDataModule:
         ],
     )
     def test_image_size(self, input_size, effective_image_size):
+        """Test if the image size parameter works as expected."""
         model_name = "stfpm"
         configurable_parameters = get_configurable_parameters(model_name)
         configurable_parameters.dataset.image_size = input_size

--- a/tests/pre_merge/datasets/test_dataset.py
+++ b/tests/pre_merge/datasets/test_dataset.py
@@ -7,7 +7,7 @@ from anomalib.config import get_configurable_parameters, update_input_size_confi
 from anomalib.data import get_datamodule
 from anomalib.data.mvtec import MVTecDataModule
 from anomalib.pre_processing.transforms import Denormalize, ToNumpy
-from tests.helpers.dataset import get_dataset_path
+from tests.helpers.dataset import TestDataset, get_dataset_path
 
 
 @pytest.fixture(autouse=True)
@@ -116,10 +116,13 @@ class TestConfigToDataModule:
             ((267, 267), (267, 267)),
         ],
     )
-    def test_image_size(self, input_size, effective_image_size):
+    @TestDataset(num_train=20, num_test=10)
+    def test_image_size(self, input_size, effective_image_size, category="shapes", path=""):
         """Test if the image size parameter works as expected."""
         model_name = "stfpm"
         configurable_parameters = get_configurable_parameters(model_name)
+        configurable_parameters.dataset.path = path
+        configurable_parameters.dataset.category = category
         configurable_parameters.dataset.image_size = input_size
         configurable_parameters = update_input_size_config(configurable_parameters)
 


### PR DESCRIPTION
# Description

- This PR fixes issues with image size in training and inference.
- Fixes type causing non-square image size to be interpreted as square when loading the datamodule.
- Fixes incorrect computation of gaussian model dimensionality in PADIM, causing model loading to fail for non-square image size.
- Adds tests to confirm that different image sizes take the desired effect.

- Fixes https://github.com/openvinotoolkit/anomalib/issues/83

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
