### PR TITLE
optimize compute_anomaly_score by using torch native funcrtions

### DIFF
--- a/anomalib/models/patchcore/model.py
+++ b/anomalib/models/patchcore/model.py
@@ -74,9 +74,10 @@ class AnomalyMapGenerator:
         Returns:
             torch.Tensor: Image-level anomaly scores
         """
-        confidence = patch_scores[torch.argmax(patch_scores[:, 0])]
+        max_scores = torch.argmax(patch_scores[:, 0])
+        confidence = torch.index_select(patch_scores, 0, max_scores)
         weights = 1 - (torch.max(torch.exp(confidence)) / torch.sum(torch.exp(confidence)))
-        score = weights * max(patch_scores[:, 0])
+        score = weights * torch.max(patch_scores[:, 0])
         return score
 
     def __call__(self, **kwargs: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:


### PR DESCRIPTION
Hey,
I realized that the `compute_anomy_score` method https://github.com/openvinotoolkit/anomalib/blob/ee8807b48d7c5ccfe9f5ff976fb6d6dac0247f0a/anomalib/models/patchcore/model.py#L69 can be optimized by using torch native functions that might vectorize better.

Using a GPU, the execution time reduces from `0.17330350000000116s` to `0.00022549999999910142s` (~700x faster)