### PR TITLE
Generalize PatchCore to support feature map sizes other than (28, 28).

### DIFF
--- a/anomalib/models/patchcore/model.py
+++ b/anomalib/models/patchcore/model.py
@@ -41,7 +41,7 @@ class AnomalyMapGenerator:
     def __init__(
         self,
         input_size: Union[ListConfig, Tuple],
-        feature_map_size: Tuple,
+        feature_map_size: Tuple[int, int],
         sigma: int = 4,
     ) -> None:
         self.input_size = input_size


### PR DESCRIPTION
# Description

This PR generalizes the PatchCore model to support different input sizes and different layers of the ResNet models.
This is implemented by inferring the pooling/downsampling ratio from the layer names.
The ratio is then used to calculate the feature map size.
The largest feature map size is used in the AnomalyMapGenerator to recreate the shape of the 2D-shape from the 1D-embedding.

It assumes the layer names and downsampling ratios are the same as in the torchvision implementation of ResNet.

- Fixes issue #40 for ResNets.

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
