### PR TITLE
Fix IndexError in adaptive threshold computation

### DIFF
--- a/anomalib/utils/metrics/adaptive_threshold.py
+++ b/anomalib/utils/metrics/adaptive_threshold.py
@@ -37,5 +37,10 @@ class AdaptiveThreshold(Metric):
 
         precision, recall, thresholds = self.precision_recall_curve.compute()
         f1_score = (2 * precision * recall) / (precision + recall + 1e-10)
-        self.value = thresholds[torch.argmax(f1_score)]
+        if thresholds.dim() == 0:
+            # special case where recall is 1.0 even for the highest threshold.
+            # In this case 'thresholds' will be scalar.
+            self.value = thresholds
+        else:
+            self.value = thresholds[torch.argmax(f1_score)]
         return self.value

--- a/tests/pre_merge/utils/metrics/__init__.py
+++ b/tests/pre_merge/utils/metrics/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (C) 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.

--- a/tests/pre_merge/utils/metrics/test_adaptive_threshold.py
+++ b/tests/pre_merge/utils/metrics/test_adaptive_threshold.py
@@ -1,0 +1,37 @@
+"""Tests for the adaptive threshold metric."""
+
+# Copyright (C) 2020 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+import pytest
+import torch
+
+from anomalib.utils.metrics import AdaptiveThreshold
+
+
+@pytest.mark.parametrize(
+    ["labels", "preds", "target_threshold"],
+    [
+        (torch.Tensor([0, 0, 0, 1, 1]), torch.Tensor([2.3, 1.6, 2.6, 7.9, 3.3]), 3.3),  # standard case
+        (torch.Tensor([1, 0, 0, 0]), torch.Tensor([4, 3, 2, 1]), 4),  # 100% recall for all thresholds
+    ],
+)
+def test_adaptive_threshold(labels, preds, target_threshold):
+    """Test if the adaptive threshold computation returns the desired value."""
+
+    adaptive_threshold = AdaptiveThreshold(default_value=0.5)
+    adaptive_threshold.update(preds, labels)
+    threshold_value = adaptive_threshold.compute()
+
+    assert threshold_value == target_threshold


### PR DESCRIPTION
# Description

- This PR addresses a bug causing validation to fail when computing the adaptive threshold. In rare cases (e.g. few anomalous images in validation set), it is possible that the recall is 1.0 for all threshold values included in TorchMetrics precision-recall curve computation. In this case, the `thresholds` tensor gets reduced to a scalar value, and trying to retrieve the first item produces an `IndexError`. In this case we can safely return the scalar threshold value instead.

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
