### PR TITLE
fix non-adaptive thresholding bug

### DIFF
--- a/anomalib/models/components/base/anomaly_module.py
+++ b/anomalib/models/components/base/anomaly_module.py
@@ -58,10 +58,12 @@ class AnomalyModule(pl.LightningModule, ABC):
         self.model: nn.Module
 
         # metrics
-        auroc = AUROC(num_classes=1, pos_label=1, compute_on_step=False)
-        f1_score = F1(num_classes=1, compute_on_step=False)
-        self.image_metrics = MetricCollection([auroc, f1_score], prefix="image_").cpu()
-        self.pixel_metrics = self.image_metrics.clone(prefix="pixel_").cpu()
+        image_auroc = AUROC(num_classes=1, pos_label=1, compute_on_step=False)
+        image_f1 = F1(num_classes=1, compute_on_step=False, threshold=self.hparams.model.threshold.image_default)
+        pixel_auroc = AUROC(num_classes=1, pos_label=1, compute_on_step=False)
+        pixel_f1 = F1(num_classes=1, compute_on_step=False, threshold=self.hparams.model.threshold.pixel_default)
+        self.image_metrics = MetricCollection([image_auroc, image_f1], prefix="image_").cpu()
+        self.pixel_metrics = MetricCollection([pixel_auroc, pixel_f1], prefix="pixel_").cpu()
 
     def forward(self, batch):  # pylint: disable=arguments-differ
         """Forward-pass input tensor to the module.


### PR DESCRIPTION
# Description

- Uses the default threshold values specified by the user when creating the F1 metrics. This makes sure that when adaptive thresholding is disabled, and no normalization is used, the F1 computation will be based on the user-specified threshold.
- Adds a test case that checks if the thresholds get assigned correctly in the above conditions.

- Fixes https://github.com/openvinotoolkit/anomalib/issues/139

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
