### PR TITLE
Added extension as an option when saving the result images.

### DIFF
--- a/anomalib/models/dfkde/model.py
+++ b/anomalib/models/dfkde/model.py
@@ -104,7 +104,7 @@ class DfkdeLightning(AnomalyModule):
         self.embeddings: List[Tensor] = []
 
     @staticmethod
-    def configure_optimizers():
+    def configure_optimizers():  # pylint: disable=arguments-differ
         """DFKDE doesn't require optimization, therefore returns no optimizers."""
         return None
 

--- a/anomalib/models/dfm/model.py
+++ b/anomalib/models/dfm/model.py
@@ -38,7 +38,7 @@ class DfmLightning(AnomalyModule):
         self.embeddings: List[Tensor] = []
 
     @staticmethod
-    def configure_optimizers() -> None:
+    def configure_optimizers() -> None:  # pylint: disable=arguments-differ
         """DFM doesn't require optimization, therefore returns no optimizers."""
         return None
 

--- a/anomalib/models/padim/model.py
+++ b/anomalib/models/padim/model.py
@@ -298,7 +298,7 @@ class PadimLightning(AnomalyModule):
         self.embeddings: List[Tensor] = []
 
     @staticmethod
-    def configure_optimizers():
+    def configure_optimizers():  # pylint: disable=arguments-differ
         """PADIM doesn't require optimization, therefore returns no optimizers."""
         return None
 

--- a/anomalib/utils/callbacks/visualizer_callback.py
+++ b/anomalib/utils/callbacks/visualizer_callback.py
@@ -44,7 +44,12 @@ class VisualizerCallback(Callback):
         """Visualizer callback."""
         self.inputs_are_normalized = inputs_are_normalized
 
-    def _add_images(self, visualizer: Visualizer, module: AnomalyModule, filename: Path, extension: str = ".png"):
+    def _add_images(
+        self,
+        visualizer: Visualizer,
+        module: AnomalyModule,
+        filename: Path,
+    ):
         """Save image to logger/local storage.
 
         Saves the image in `visualizer.figure` to the respective loggers and local storage if specified in
@@ -54,7 +59,6 @@ class VisualizerCallback(Callback):
             visualizer (Visualizer): Visualizer object from which the `figure` is saved/logged.
             module (AnomalyModule): Anomaly module which holds reference to `hparams` and `logger`.
             filename (Path): Path of the input image. This name is used as name for the generated image.
-            extension (str, optional): File extension to save the image. Defaults to `.png`.
         """
 
         # store current logger type as a string
@@ -77,15 +81,7 @@ class VisualizerCallback(Callback):
                     )
 
         if "local" in module.hparams.project.log_images_to:
-            extension = (
-                filename.suffix
-                if filename.suffix
-                in ("eps", "jpeg", "jpg", "pdf", "pgf", "png", "ps", "raw", "rgba", "svg", "svgz", "tif", "tiff")
-                else ".png"
-            )
-            visualizer.save(
-                Path(module.hparams.project.path) / "images" / filename.parent.name / (filename.suffix + extension)
-            )
+            visualizer.save(Path(module.hparams.project.path) / "images" / filename.parent.name / filename.name)
 
     def on_test_batch_end(
         self,

--- a/anomalib/utils/callbacks/visualizer_callback.py
+++ b/anomalib/utils/callbacks/visualizer_callback.py
@@ -77,8 +77,14 @@ class VisualizerCallback(Callback):
                     )
 
         if "local" in module.hparams.project.log_images_to:
+            extension = (
+                filename.suffix
+                if filename.suffix
+                in ("eps", "jpeg", "jpg", "pdf", "pgf", "png", "ps", "raw", "rgba", "svg", "svgz", "tif", "tiff")
+                else ".png"
+            )
             visualizer.save(
-                Path(module.hparams.project.path) / "images" / filename.parent.name / (filename.stem + extension)
+                Path(module.hparams.project.path) / "images" / filename.parent.name / (filename.suffix + extension)
             )
 
     def on_test_batch_end(

--- a/anomalib/utils/callbacks/visualizer_callback.py
+++ b/anomalib/utils/callbacks/visualizer_callback.py
@@ -44,12 +44,7 @@ class VisualizerCallback(Callback):
         """Visualizer callback."""
         self.inputs_are_normalized = inputs_are_normalized
 
-    def _add_images(
-        self,
-        visualizer: Visualizer,
-        module: AnomalyModule,
-        filename: Path,
-    ):
+    def _add_images(self, visualizer: Visualizer, module: AnomalyModule, filename: Path, extension: str = ".png"):
         """Save image to logger/local storage.
 
         Saves the image in `visualizer.figure` to the respective loggers and local storage if specified in
@@ -59,6 +54,7 @@ class VisualizerCallback(Callback):
             visualizer (Visualizer): Visualizer object from which the `figure` is saved/logged.
             module (AnomalyModule): Anomaly module which holds reference to `hparams` and `logger`.
             filename (Path): Path of the input image. This name is used as name for the generated image.
+            extension (str, optional): File extension to save the image. Defaults to `.png`.
         """
 
         # store current logger type as a string
@@ -81,7 +77,9 @@ class VisualizerCallback(Callback):
                     )
 
         if "local" in module.hparams.project.log_images_to:
-            visualizer.save(Path(module.hparams.project.path) / "images" / filename.parent.name / filename.name)
+            visualizer.save(
+                Path(module.hparams.project.path) / "images" / filename.parent.name / (filename.stem + extension)
+            )
 
     def on_test_batch_end(
         self,

--- a/tox.ini
+++ b/tox.ini
@@ -106,6 +106,7 @@ ignore = E203,W503
 extension-pkg-whitelist = cv2
 ignored-modules = cv2
 disable = duplicate-code,
+          arguments-differ,
           fixme,
           import-error,
           no-self-use,


### PR DESCRIPTION
# Description

- This PR converts `bmp` images to `png` after downloading and extracting the `BTech` dataset. 
Each BTech category has different image extension as follows

| Category | Image | Mask |
|----------|-------|------|
| 01       | bmp   | png  |
| 02       | png   | png  |
| 03       | bmp   | bmp  |

To avoid any conflict, the following script converts all the extensions to png. This solution works fine, but it's also possible to properly ready the bmp and png filenames from categories in `make_btech_dataset` function.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
