### PR TITLE
Fix `KeyError:'label'` in classification folder dataset

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
 
   # python code formatting
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
         args: [--line-length, "120"]

--- a/anomalib/data/folder.py
+++ b/anomalib/data/folder.py
@@ -236,10 +236,10 @@ class FolderDataset(Dataset):
         image_path = self.samples.image_path[index]
         image = read_image(image_path)
 
-        if self.split == "train" or self.task == "classification":
-            pre_processed = self.pre_process(image=image)
-            item = {"image": pre_processed["image"]}
-        elif self.split in ["val", "test"]:
+        pre_processed = self.pre_process(image=image)
+        item = {"image": pre_processed["image"]}
+
+        if self.split in ["val", "test"]:
             label_index = self.samples.label_index[index]
 
             item["image_path"] = image_path

--- a/anomalib/models/cflow/model.py
+++ b/anomalib/models/cflow/model.py
@@ -46,7 +46,7 @@ def get_logp(dim_feature_vector: int, p_u: torch.Tensor, logdet_j: torch.Tensor)
         torch.Tensor: Log probability
     """
     ln_sqrt_2pi = -np.log(np.sqrt(2 * np.pi))  # ln(sqrt(2*pi))
-    logp = dim_feature_vector * ln_sqrt_2pi - 0.5 * torch.sum(p_u ** 2, 1) + logdet_j
+    logp = dim_feature_vector * ln_sqrt_2pi - 0.5 * torch.sum(p_u**2, 1) + logdet_j
     return logp
 
 

--- a/anomalib/models/components/dimensionality_reduction/random_projection.py
+++ b/anomalib/models/components/dimensionality_reduction/random_projection.py
@@ -99,7 +99,7 @@ class SparseRandomProjection:
             eps (float, optional): Minimum distortion rate. Defaults to 0.1.
         """
 
-        denominator = (eps ** 2 / 2) - (eps ** 3 / 3)
+        denominator = (eps**2 / 2) - (eps**3 / 3)
         return (4 * np.log(n_samples) / denominator).astype(np.int64)
 
     def fit(self, embedding: Tensor) -> "SparseRandomProjection":

--- a/anomalib/models/components/stats/kde.py
+++ b/anomalib/models/components/stats/kde.py
@@ -78,7 +78,7 @@ class GaussianKDE(DynamicBufferModule):
 
         cov_mat = self.cov(dataset.T)
         inv_cov_mat = torch.linalg.inv(cov_mat)
-        inv_cov = inv_cov_mat / factor ** 2
+        inv_cov = inv_cov_mat / factor**2
 
         # transform data to account for bandwidth
         bw_transform = torch.linalg.cholesky(inv_cov)

--- a/anomalib/models/ganomaly/torch_model.py
+++ b/anomalib/models/ganomaly/torch_model.py
@@ -116,7 +116,7 @@ class Decoder(nn.Module):
 
         # Calculate input channel size to recreate inverse pyramid
         exp_factor = int(math.log(input_size // 4, 2)) - 1
-        n_input_features = n_features * (2 ** exp_factor)
+        n_input_features = n_features * (2**exp_factor)
 
         # CNN layer for latent vector input
         self.latent_input.add_module(

--- a/anomalib/utils/callbacks/visualizer_callback.py
+++ b/anomalib/utils/callbacks/visualizer_callback.py
@@ -111,25 +111,26 @@ class VisualizerCallback(Callback):
             normalize = True  # raw anomaly maps. Still need to normalize
         threshold = pl_module.pixel_metrics.F1.threshold
 
-        for (filename, image, true_mask, anomaly_map) in zip(
-            outputs["image_path"], outputs["image"], outputs["mask"], outputs["anomaly_maps"]
-        ):
-            image = Denormalize()(image.cpu())
-            true_mask = true_mask.cpu().numpy()
-            anomaly_map = anomaly_map.cpu().numpy()
+        if isinstance(outputs, dict) and "mask" in outputs.keys():
+            for (filename, image, true_mask, anomaly_map) in zip(
+                outputs["image_path"], outputs["image"], outputs["mask"], outputs["anomaly_maps"]
+            ):
+                image = Denormalize()(image.cpu())
+                true_mask = true_mask.cpu().numpy()
+                anomaly_map = anomaly_map.cpu().numpy()
 
-            heat_map = superimpose_anomaly_map(anomaly_map, image, normalize=normalize)
-            pred_mask = compute_mask(anomaly_map, threshold)
-            vis_img = mark_boundaries(image, pred_mask, color=(1, 0, 0), mode="thick")
+                heat_map = superimpose_anomaly_map(anomaly_map, image, normalize=normalize)
+                pred_mask = compute_mask(anomaly_map, threshold)
+                vis_img = mark_boundaries(image, pred_mask, color=(1, 0, 0), mode="thick")
 
-            visualizer = Visualizer(num_rows=1, num_cols=5, figure_size=(12, 3))
-            visualizer.add_image(image=image, title="Image")
-            visualizer.add_image(image=true_mask, color_map="gray", title="Ground Truth")
-            visualizer.add_image(image=heat_map, title="Predicted Heat Map")
-            visualizer.add_image(image=pred_mask, color_map="gray", title="Predicted Mask")
-            visualizer.add_image(image=vis_img, title="Segmentation Result")
-            self._add_images(visualizer, pl_module, Path(filename))
-            visualizer.close()
+                visualizer = Visualizer(num_rows=1, num_cols=5, figure_size=(12, 3))
+                visualizer.add_image(image=image, title="Image")
+                visualizer.add_image(image=true_mask, color_map="gray", title="Ground Truth")
+                visualizer.add_image(image=heat_map, title="Predicted Heat Map")
+                visualizer.add_image(image=pred_mask, color_map="gray", title="Predicted Mask")
+                visualizer.add_image(image=vis_img, title="Segmentation Result")
+                self._add_images(visualizer, pl_module, Path(filename))
+                visualizer.close()
 
     def on_test_end(self, _trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
         """Sync logs.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,8 +1,8 @@
-black
+black==22.3.0
 coverage
 flake8
 flaky
-isort
+isort==5.10.1
 mypy
 pytest
 pylint

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist =
 
 [testenv:black]
 basepython = python3
-deps = black==20.8b1
+deps = black==22.3.0
 commands = black --check --diff anomalib -l 120
 
 [testenv:isort]


### PR DESCRIPTION
# Description

- This hotfix proposes a fix to return `label` in `folder` dataset when `classification` task is chosen. Currently the `folder` dataset doesn't return `label` in `classification`, which ultimately causes a failed validation.
- PR also bumps up the black version due to a version dependency, resulting in some changes in some modules.

- Fixes #173

## Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
