### PR TITLE
Remove task parameter

### DIFF
--- a/anomalib/data/__init__.py
+++ b/anomalib/data/__init__.py
@@ -67,7 +67,6 @@ def get_datamodule(config: Union[DictConfig, ListConfig]) -> LightningDataModule
             root=config.dataset.path,
             normal=config.dataset.normal,
             abnormal=config.dataset.abnormal,
-            task=config.dataset.task,
             mask_dir=config.dataset.mask,
             extensions=config.dataset.extensions,
             split_ratio=config.dataset.split_ratio,

--- a/anomalib/data/folder.py
+++ b/anomalib/data/folder.py
@@ -162,7 +162,6 @@ class FolderDataset(Dataset):
         split_ratio: float = 0.2,
         mask_dir: Optional[Union[Path, str]] = None,
         extensions: Optional[Tuple[str, ...]] = None,
-        task: str = "segmentation",
         seed: int = 0,
         create_validation_set: bool = False,
     ) -> None:
@@ -181,7 +180,6 @@ class FolderDataset(Dataset):
                 the mask annotations. Defaults to None.
             extensions (Optional[Tuple[str, ...]], optional): Type of the image extensions to read from the
                 directory.
-            task (Optional[str], optional): Task type. (classification or segmentation) Defaults to None.
             seed (int, optional): Random seed to ensure reproducibility when splitting. Defaults to 0.
             create_validation_set (bool, optional):Boolean to create a validation set from the test set.
                 Those wanting to create a validation set could set this flag to ``True``.
@@ -192,7 +190,7 @@ class FolderDataset(Dataset):
 
         """
         self.split = split
-        self.task = task
+        self.task = "classification" if mask_dir is None else "segmentation"
 
         self.pre_process = pre_process
         self.samples = make_dataset(
@@ -280,8 +278,6 @@ class FolderDataModule(LightningDataModule):
                 Defaults to "normal".
             abnormal (str, optional): Name of the directory containing abnormal images.
                 Defaults to "abnormal".
-            task (str, optional): Task type. Could be either classification or segmentation.
-                Defaults to "classification".
             mask_dir (Optional[Union[str, Path]], optional): Path to the directory containing
                 the mask annotations. Defaults to None.
             extensions (Optional[Tuple[str, ...]], optional): Type of the image extensions to read from the
@@ -373,7 +369,6 @@ class FolderDataModule(LightningDataModule):
         self.extensions = extensions
         self.split_ratio = split_ratio
 
-        self.task = "classification" if mask_dir is None else "segmentation"
         self.transform_config = transform_config
         self.image_size = image_size
 
@@ -408,7 +403,6 @@ class FolderDataModule(LightningDataModule):
                 mask_dir=self.mask_dir,
                 pre_process=self.pre_process,
                 extensions=self.extensions,
-                task=self.task,
                 seed=self.seed,
                 create_validation_set=self.create_validation_set,
             )
@@ -422,7 +416,6 @@ class FolderDataModule(LightningDataModule):
                 mask_dir=self.mask_dir,
                 pre_process=self.pre_process,
                 extensions=self.extensions,
-                task=self.task,
                 seed=self.seed,
                 create_validation_set=self.create_validation_set,
             )
@@ -435,7 +428,6 @@ class FolderDataModule(LightningDataModule):
             mask_dir=self.mask_dir,
             pre_process=self.pre_process,
             extensions=self.extensions,
-            task=self.task,
             seed=self.seed,
             create_validation_set=self.create_validation_set,
         )

--- a/anomalib/data/folder.py
+++ b/anomalib/data/folder.py
@@ -162,7 +162,6 @@ class FolderDataset(Dataset):
         split_ratio: float = 0.2,
         mask_dir: Optional[Union[Path, str]] = None,
         extensions: Optional[Tuple[str, ...]] = None,
-        task: Optional[str] = None,
         seed: int = 0,
         create_validation_set: bool = False,
     ) -> None:
@@ -192,16 +191,7 @@ class FolderDataset(Dataset):
 
         """
         self.split = split
-
-        if task == "classification" and mask_dir:
-            raise ValueError(
-                "Classification task is requested, but mask directory is provided. "
-                "Segmentation task is to be chosen if mask directory is provided."
-            )
-        if task is None or mask_dir is None:
-            self.task = "classification"
-        else:
-            self.task = task
+        self.task = "classification" if mask_dir is None else "segmentation"
 
         self.pre_process = pre_process
         self.samples = make_dataset(
@@ -424,7 +414,6 @@ class FolderDataModule(LightningDataModule):
                 mask_dir=self.mask_dir,
                 pre_process=self.pre_process,
                 extensions=self.extensions,
-                task=self.task,
                 seed=self.seed,
                 create_validation_set=self.create_validation_set,
             )
@@ -438,7 +427,6 @@ class FolderDataModule(LightningDataModule):
                 mask_dir=self.mask_dir,
                 pre_process=self.pre_process,
                 extensions=self.extensions,
-                task=self.task,
                 seed=self.seed,
                 create_validation_set=self.create_validation_set,
             )
@@ -451,7 +439,6 @@ class FolderDataModule(LightningDataModule):
             mask_dir=self.mask_dir,
             pre_process=self.pre_process,
             extensions=self.extensions,
-            task=self.task,
             seed=self.seed,
             create_validation_set=self.create_validation_set,
         )

--- a/anomalib/data/folder.py
+++ b/anomalib/data/folder.py
@@ -162,6 +162,7 @@ class FolderDataset(Dataset):
         split_ratio: float = 0.2,
         mask_dir: Optional[Union[Path, str]] = None,
         extensions: Optional[Tuple[str, ...]] = None,
+        task: str = "segmentation",
         seed: int = 0,
         create_validation_set: bool = False,
     ) -> None:
@@ -191,7 +192,7 @@ class FolderDataset(Dataset):
 
         """
         self.split = split
-        self.task = "classification" if mask_dir is None else "segmentation"
+        self.task = task
 
         self.pre_process = pre_process
         self.samples = make_dataset(
@@ -260,7 +261,6 @@ class FolderDataModule(LightningDataModule):
         root: Union[str, Path],
         normal: str = "normal",
         abnormal: str = "abnormal",
-        task: str = "classification",
         mask_dir: Optional[Union[Path, str]] = None,
         extensions: Optional[Tuple[str, ...]] = None,
         split_ratio: float = 0.2,
@@ -373,13 +373,7 @@ class FolderDataModule(LightningDataModule):
         self.extensions = extensions
         self.split_ratio = split_ratio
 
-        if task == "classification" and mask_dir is not None:
-            raise ValueError(
-                "Classification type is set but mask_dir provided. "
-                "If mask_dir is provided task type must be segmentation. "
-                "Check your configuration."
-            )
-        self.task = task
+        self.task = "classification" if mask_dir is None else "segmentation"
         self.transform_config = transform_config
         self.image_size = image_size
 
@@ -414,6 +408,7 @@ class FolderDataModule(LightningDataModule):
                 mask_dir=self.mask_dir,
                 pre_process=self.pre_process,
                 extensions=self.extensions,
+                task=self.task,
                 seed=self.seed,
                 create_validation_set=self.create_validation_set,
             )
@@ -427,6 +422,7 @@ class FolderDataModule(LightningDataModule):
                 mask_dir=self.mask_dir,
                 pre_process=self.pre_process,
                 extensions=self.extensions,
+                task=self.task,
                 seed=self.seed,
                 create_validation_set=self.create_validation_set,
             )
@@ -439,6 +435,7 @@ class FolderDataModule(LightningDataModule):
             mask_dir=self.mask_dir,
             pre_process=self.pre_process,
             extensions=self.extensions,
+            task=self.task,
             seed=self.seed,
             create_validation_set=self.create_validation_set,
         )

--- a/anomalib/models/cflow/config.yaml
+++ b/anomalib/models/cflow/config.yaml
@@ -3,7 +3,6 @@ dataset:
   format: mvtec
   path: ./datasets/MVTec
   category: bottle
-  task: segmentation
   image_size: 256
   train_batch_size: 16
   test_batch_size: 16

--- a/anomalib/models/components/base/anomaly_module.py
+++ b/anomalib/models/components/base/anomaly_module.py
@@ -181,5 +181,5 @@ class AnomalyModule(pl.LightningModule, ABC):
     def _log_metrics(self):
         """Log computed performance metrics."""
         self.log_dict(self.image_metrics)
-        if self.hparams.dataset.task == "segmentation":
+        if self.pixel_metrics.AUROC.update_called:
             self.log_dict(self.pixel_metrics)

--- a/anomalib/models/dfkde/config.yaml
+++ b/anomalib/models/dfkde/config.yaml
@@ -3,7 +3,6 @@ dataset:
   format: mvtec
   path: ./datasets/MVTec
   category: bottle
-  task: classification
   image_size: 256
   train_batch_size: 32
   test_batch_size: 32

--- a/anomalib/models/dfm/config.yaml
+++ b/anomalib/models/dfm/config.yaml
@@ -3,7 +3,6 @@ dataset:
   format: mvtec
   path: ./datasets/MVTec
   category: bottle
-  task: classification
   image_size: 256
   train_batch_size: 32
   test_batch_size: 32

--- a/anomalib/models/ganomaly/config.yaml
+++ b/anomalib/models/ganomaly/config.yaml
@@ -3,7 +3,6 @@ dataset:
   format: mvtec
   path: ./datasets/MVTec
   category: bottle
-  task: classification
   image_size: 256
   train_batch_size: 32
   test_batch_size: 32

--- a/anomalib/models/padim/config.yaml
+++ b/anomalib/models/padim/config.yaml
@@ -3,7 +3,6 @@ dataset:
   format: mvtec
   path: ./datasets/MVTec
   category: bottle
-  task: segmentation
   image_size: 256
   train_batch_size: 32
   test_batch_size: 32

--- a/anomalib/models/patchcore/config.yaml
+++ b/anomalib/models/patchcore/config.yaml
@@ -2,7 +2,6 @@ dataset:
   name: mvtec #options: [mvtec, btech, folder]
   format: mvtec
   path: ./datasets/MVTec
-  task: segmentation
   category: bottle
   image_size: 224
   train_batch_size: 32

--- a/anomalib/models/stfpm/config.yaml
+++ b/anomalib/models/stfpm/config.yaml
@@ -3,7 +3,6 @@ dataset:
   format: mvtec
   path: ./datasets/MVTec
   category: bottle
-  task: segmentation
   image_size: 256
   train_batch_size: 32
   test_batch_size: 32

--- a/anomalib/utils/metrics/auroc.py
+++ b/anomalib/utils/metrics/auroc.py
@@ -22,3 +22,8 @@ class AUROC(ROC):
         if not (torch.all(fpr.diff() <= 0) or torch.all(fpr.diff() >= 0)):
             return auc(fpr, tpr, reorder=True)  # only reorder if fpr is not increasing or decreasing
         return auc(fpr, tpr)
+
+    @property
+    def update_called(self) -> bool:
+        """Returns a boolean indicating if the update method has been called at least once."""
+        return self._update_called

--- a/tests/helpers/model.py
+++ b/tests/helpers/model.py
@@ -141,7 +141,7 @@ def model_load_test(config: Union[DictConfig, ListConfig], datamodule: Lightning
     assert np.isclose(
         results["image_AUROC"], new_results["image_AUROC"]
     ), "Loaded model does not yield close performance results"
-    if config.dataset.task == "segmentation":
+    if "pixel_AUROC" in results.keys():
         assert np.isclose(
             results["pixel_AUROC"], new_results["pixel_AUROC"]
         ), "Loaded model does not yield close performance results"

--- a/tests/pre_merge/datasets/test_dataset.py
+++ b/tests/pre_merge/datasets/test_dataset.py
@@ -58,7 +58,6 @@ def folder_data_module():
         normal="good",
         abnormal="broken_large",
         mask_dir=os.path.join(root, "ground_truth/broken_large"),
-        task="segmentation",
         split_ratio=0.2,
         seed=0,
         image_size=(256, 256),


### PR DESCRIPTION
# Description

- This PR removes the `config.dataset.task` parameter, which was redundant.
- The data modules now check if ground truth mask annotations are available to determine the task type.
- The anomaly module now checks if the pixel metrics have been updated before attempting to compute the metrics.

- Fixes https://github.com/openvinotoolkit/anomalib/issues/34

## Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
