### PR TITLE
Allow specifying feature layer and pool factor in DFM

### DIFF
--- a/anomalib/models/dfm/config.yaml
+++ b/anomalib/models/dfm/config.yaml
@@ -15,7 +15,7 @@ model:
   name: dfm
   backbone: resnet18
   layer: layer3
-  pool: 4
+  pooling_kernel_size: 4
   pca_level: 0.97
   score_type: fre # nll: for Gaussian modeling, fre: pca feature reconstruction error
   project_path: ./results

--- a/anomalib/models/dfm/config.yaml
+++ b/anomalib/models/dfm/config.yaml
@@ -14,6 +14,8 @@ dataset:
 model:
   name: dfm
   backbone: resnet18
+  layer: layer3
+  pool: 4
   pca_level: 0.97
   score_type: fre # nll: for Gaussian modeling, fre: pca feature reconstruction error
   project_path: ./results

--- a/anomalib/models/dfm/model.py
+++ b/anomalib/models/dfm/model.py
@@ -32,8 +32,11 @@ class DfmLightning(AnomalyModule):
         super().__init__(hparams)
 
         self.model: DFMModel = DFMModel(
-            backbone=hparams.model.backbone, layer=hparams.model.layer, pool=hparams.model.pool, 
-            n_comps=hparams.model.pca_level, score_type=hparams.model.score_type
+            backbone=hparams.model.backbone,
+            layer=hparams.model.layer,
+            pooling_kernel_size=hparams.model.pooling_kernel_size,
+            n_comps=hparams.model.pca_level,
+            score_type=hparams.model.score_type,
         )
         self.automatic_optimization = False
         self.embeddings: List[Tensor] = []

--- a/anomalib/models/dfm/model.py
+++ b/anomalib/models/dfm/model.py
@@ -32,7 +32,8 @@ class DfmLightning(AnomalyModule):
         super().__init__(hparams)
 
         self.model: DFMModel = DFMModel(
-            backbone=hparams.model.backbone, n_comps=hparams.model.pca_level, score_type=hparams.model.score_type
+            backbone=hparams.model.backbone, layer=hparams.model.layer, pool=hparams.model.pool, 
+            n_comps=hparams.model.pca_level, score_type=hparams.model.score_type
         )
         self.automatic_optimization = False
         self.embeddings: List[Tensor] = []


### PR DESCRIPTION
# Description

- Two additional parameters need to be specified for DFM: name of the layer from which features are extracted, and an integer pool factor. The features will be average-pooled by the specified pool factor before DFM is applied.

- Fixes # (issue)

## Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
