### PR TITLE
Updated documentation for development on Docker

### DIFF
--- a/docs/source/guides/developing_on_docker.rst
+++ b/docs/source/guides/developing_on_docker.rst
@@ -3,21 +3,39 @@
 Developing on Docker
 ======================
 
-.. note:: Assumes you have GPU on your system with the correct drivers installed
+.. note:: You need a CUDA-capable GPU with suitable drivers installed
 
-1.	Install `VSCode <https://code.visualstudio.com/download>`_
-2.	Install `Docker <https://docs.docker.com/engine/install/>`_
-3.	Install `NVIDIA Container Toolkit <https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html>`_
+1. Install `Docker <https://docs.docker.com/engine/install/>`_
+2. Install `NVIDIA Container Toolkit <https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html>`_
 
-.. warning:: Make sure your user is added to the docker group. First check by typing ``groups`` in terminal. If     ``docker`` is not listed, then use the command ``sudo usermod -aG docker $USER``.
 
-4.	Logout and log back in to ensure that user group is evaluated.
-5.	Open VSCode.
-6.	Install the Remote-Containers extension by Microsoft in VSCode.
-7.	Open command panel by pressing ``CTRL + SHIFT + P``.
-8.	Type ``Remote-Containers: Open Folder in Container`` and press Enter.
-9.	Navigate to the root of anomalib folder. (The one with Dockerfile).
-10.	Give it time to build the image and install the extensions. Grab a |:coffee:| as this will take a while for the first time as the container needs to be built.
-11.	And voilà |:confetti_ball:| you should now see your folder mounted in the docker container and begin developing. Your changes should automatically be reflected in your host directory.
+Build the Docker Image
+======================
 
-.. note:: If VSCode throws an error regarding not having sufficient privileges, try restarting the system.
+To use anomalib with Docker, you can build a Docker image containing anomalib all its dependencies from the provided Dockerfile. To this end, navigate to the anomalib root directory (the one containing the Dockerfile) and build the Docker image with
+```
+docker build . --tag=anomalib
+```
+
+
+Run the Docker Image
+====================
+
+After building the image, you can run it as follows
+```
+docker run \
+	-it --rm \
+	--ipc=host \
+	--env="DISPLAY" \
+	--gpus=all \
+	-w /anomalib \
+	-v /tmp/.X11-unix:/tmp/.X11-unix:rw \
+	-v "$(pwd)":/anomalib \
+	anomalib \
+	/bin/bash
+```
+This creates an interactive bash session inside the Docker container, in which you can run all anomalib commands as described in the `readme <https://github.com/openvinotoolkit/anomalib/blob/development/README.md>`_.
+
+The source code is mapped into the running container by means of the `-v "$(pwd)":/anomalib` parameter. This facilitates changes to the source code without having to rebuild the Docker image.
+
+.. note:: To forward graphical output of the Docker container to the host operating system, you have to disable access control of the host's X11 server. To this end, execute the shell command `xhost +` on the host.

--- a/docs/source/guides/developing_on_docker.rst
+++ b/docs/source/guides/developing_on_docker.rst
@@ -3,7 +3,8 @@
 Developing on Docker
 ======================
 
-.. note:: You need a CUDA-capable GPU with suitable drivers installed
+.. note:: 
+	You need a CUDA-capable GPU with suitable drivers installed
 
 1. Install `Docker <https://docs.docker.com/engine/install/>`_
 2. Install `NVIDIA Container Toolkit <https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html>`_
@@ -27,18 +28,19 @@ After building the image, you can run it as follows
 .. code-block:: console
 
 	docker run \
-		-it --rm \
-		--ipc=host \
-		--env="DISPLAY" \
-		--gpus=all \
-		-w /anomalib \
-		-v /tmp/.X11-unix:/tmp/.X11-unix:rw \
-		-v "$(pwd)":/anomalib \
-		anomalib \
-		/bin/bash
+	-it --rm \
+	--ipc=host \
+	--env="DISPLAY" \
+	--gpus=all \
+	-w /anomalib \
+	-v /tmp/.X11-unix:/tmp/.X11-unix:rw \
+	-v "$(pwd)":/anomalib \
+	anomalib \
+	/bin/bash
 
 This creates an interactive bash session inside the Docker container, in which you can run all anomalib commands as described in the `readme <https://github.com/openvinotoolkit/anomalib/blob/development/README.md>`_.
 
 The source code is mapped into the running container by means of the `-v "$(pwd)":/anomalib` parameter. This facilitates changes to the source code without having to rebuild the Docker image.
 
-.. note:: To forward graphical output of the Docker container to the host operating system, you have to disable access control of the host's X11 server. To this end, execute the shell command `xhost +` on the host.
+.. note:: 
+	To forward graphical output of the Docker container to the host operating system, you have to disable access control of the host's X11 server. To this end, execute the shell command `xhost +` on the host.

--- a/docs/source/guides/developing_on_docker.rst
+++ b/docs/source/guides/developing_on_docker.rst
@@ -13,27 +13,30 @@ Build the Docker Image
 ======================
 
 To use anomalib with Docker, you can build a Docker image containing anomalib all its dependencies from the provided Dockerfile. To this end, navigate to the anomalib root directory (the one containing the Dockerfile) and build the Docker image with
-```
-docker build . --tag=anomalib
-```
+
+.. code-block:: console
+
+	docker build . --tag=anomalib
 
 
 Run the Docker Image
 ====================
 
 After building the image, you can run it as follows
-```
-docker run \
-	-it --rm \
-	--ipc=host \
-	--env="DISPLAY" \
-	--gpus=all \
-	-w /anomalib \
-	-v /tmp/.X11-unix:/tmp/.X11-unix:rw \
-	-v "$(pwd)":/anomalib \
-	anomalib \
-	/bin/bash
-```
+
+.. code-block:: console
+
+	docker run \
+		-it --rm \
+		--ipc=host \
+		--env="DISPLAY" \
+		--gpus=all \
+		-w /anomalib \
+		-v /tmp/.X11-unix:/tmp/.X11-unix:rw \
+		-v "$(pwd)":/anomalib \
+		anomalib \
+		/bin/bash
+
 This creates an interactive bash session inside the Docker container, in which you can run all anomalib commands as described in the `readme <https://github.com/openvinotoolkit/anomalib/blob/development/README.md>`_.
 
 The source code is mapped into the running container by means of the `-v "$(pwd)":/anomalib` parameter. This facilitates changes to the source code without having to rebuild the Docker image.

--- a/docs/source/guides/developing_on_docker.rst
+++ b/docs/source/guides/developing_on_docker.rst
@@ -44,3 +44,19 @@ The source code is mapped into the running container by means of the `-v "$(pwd)
 
 .. note:: 
 	To forward graphical output of the Docker container to the host operating system, you have to disable access control of the host's X11 server. To this end, execute the shell command `xhost +` on the host.
+	
+	
+Using VSCode
+============
+
+You may also use the Remote-Containers extension for VSCode for deployment with Docker, which can be set up as follows:
+
+1. Install and run `VSCode <https://code.visualstudio.com/download>`_
+2. Install the Remote-Containers extension by Microsoft in VSCode.
+3. Open command panel by pressing ``CTRL + SHIFT + P``.
+4. Type ``Remote-Containers: Open Folder in Container`` and press Enter.
+5. Navigate to the root of anomalib folder. (The one with Dockerfile).
+6. Give it time to build the image and install the extensions. Grab a |:coffee:| as this will take a while for the first time as the container needs to be built.
+7. And voilà |:confetti_ball:| you should now see your folder mounted in the docker container and begin developing. Your changes should automatically be reflected in your host directory.
+
+.. note:: If VSCode throws an error regarding not having sufficient privileges, try restarting the system.


### PR DESCRIPTION
# Description

Updates the [Developing on Docker](https://github.com/openvinotoolkit/anomalib/blob/development/docs/source/guides/developing_on_docker.rst) guide following the enhancements of the Dockerfile as per #172.

Since VSCode is not a necessity for building and running the Docker container, I removed all details regarding the use of VSCode from the docs.