### PR TITLE
🛠  Fix mask filenames in folder dataset

### DIFF
--- a/anomalib/data/folder.py
+++ b/anomalib/data/folder.py
@@ -78,7 +78,7 @@ def _prepare_files_labels(
     if isinstance(extensions, str):
         extensions = (extensions,)
 
-    filenames = [f for f in path.glob(r"**/*") if f.suffix in extensions]
+    filenames = [f for f in path.glob(r"**/*") if f.suffix in extensions and not f.is_dir()]
     if len(filenames) == 0:
         raise RuntimeError(f"Found 0 {path_type} images in {path}")
 

--- a/anomalib/data/folder.py
+++ b/anomalib/data/folder.py
@@ -75,6 +75,9 @@ def _prepare_files_labels(
     if extensions is None:
         extensions = IMG_EXTENSIONS
 
+    if isinstance(extensions, str):
+        extensions = (extensions,)
+
     filenames = [f for f in path.glob(r"**/*") if f.suffix in extensions]
     if len(filenames) == 0:
         raise RuntimeError(f"Found 0 {path_type} images in {path}")
@@ -141,11 +144,10 @@ def make_dataset(
     # If a path to mask is provided, add it to the sample dataframe.
     if mask_dir is not None:
         mask_dir = _check_and_convert_path(mask_dir)
-        normal_gt = ["" for f in samples.loc[samples.label_index == 0]["image_path"]]
-        abnormal_gt = [str(mask_dir / f.name) for f in samples.loc[samples.label_index == 1]["image_path"]]
-        gt_filenames = normal_gt + abnormal_gt
-
-        samples["mask_path"] = gt_filenames
+        samples["mask_path"] = ""
+        for index, row in samples.iterrows():
+            if row.label_index == 1:
+                samples["mask_path"][index] = str(mask_dir / row.image_path.name)
 
     # Ensure the pathlib objects are converted to str.
     # This is because torch dataloader doesn't like pathlib.
@@ -463,6 +465,7 @@ class FolderDataModule(LightningDataModule):
             self.train_data = FolderDataset(
                 normal_dir=self.normal_dir,
                 abnormal_dir=self.abnormal_dir,
+                normal_test_dir=self.normal_test,
                 split="train",
                 split_ratio=self.split_ratio,
                 mask_dir=self.mask_dir,
@@ -477,6 +480,7 @@ class FolderDataModule(LightningDataModule):
             self.val_data = FolderDataset(
                 normal_dir=self.normal_dir,
                 abnormal_dir=self.abnormal_dir,
+                normal_test_dir=self.normal_test,
                 split="val",
                 split_ratio=self.split_ratio,
                 mask_dir=self.mask_dir,


### PR DESCRIPTION
# Description

- This PR fixes mask filenames that are incorrectly assigned in certain edge cases.

- Fixes #243 

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
