### PR TITLE
Prevent folders from being added to the samples

### DIFF
--- a/anomalib/data/folder.py
+++ b/anomalib/data/folder.py
@@ -75,7 +75,7 @@ def _prepare_files_labels(
     if extensions is None:
         extensions = IMG_EXTENSIONS
 
-    filenames = [f for f in path.glob(r"**/*") if f.suffix in extensions]
+    filenames = [f for f in path.glob(r"**/*") if f.suffix in extensions and not f.is_dir()]
     if len(filenames) == 0:
         raise RuntimeError(f"Found 0 {path_type} images in {path}")
 


### PR DESCRIPTION
This change prevents folders from being scanned and added to the data samples.