### PR TITLE
🔧  Properly assign values to dataframe in folder dataset.

### DIFF
--- a/anomalib/data/folder.py
+++ b/anomalib/data/folder.py
@@ -146,7 +146,7 @@ def make_dataset(
         samples["mask_path"] = ""
         for index, row in samples.iterrows():
             if row.label_index == 1:
-                samples["mask_path"][index] = str(mask_dir / row.image_path.name)
+                samples.loc[index, "mask_path"] = str(mask_dir / row.image_path.name)
 
     # Ensure the pathlib objects are converted to str.
     # This is because torch dataloader doesn't like pathlib.


### PR DESCRIPTION
# Description

- Currently folder dataset directly assigns values to dataframe without using `.loc`, which causes the following warning:
```
SettingWithCopyWarning:
A value is trying to be set on a copy of a slice from a DataFrame

See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
```
- This PR fixes this by properly assigning values to dataframe rows.

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
