### PR TITLE
add input_info to nncf config when not defined by user

### DIFF
--- a/anomalib/config/config.py
+++ b/anomalib/config/config.py
@@ -64,6 +64,8 @@ def update_nncf_config(config: Union[DictConfig, ListConfig]) -> Union[DictConfi
     sample_size = (crop_size, crop_size) if isinstance(crop_size, int) else crop_size
     if "optimization" in config.keys():
         if "nncf" in config.optimization.keys():
+            if "input_info" not in config.optimization.nncf.keys():
+                config.optimization.nncf["input_info"] = {"sample_size": None}
             config.optimization.nncf.input_info.sample_size = [1, 3, *sample_size]
             if config.optimization.nncf.apply:
                 if "update_config" in config.optimization.nncf:


### PR DESCRIPTION
# Description

- Adds input_info to the NNCF config when this has not been defined by the user in the `config.yaml`.

This allows users to enable NNCF by adding the following to `config.yaml`:
```
optimization:
    nncf:
        apply: true
```

Where previously, the following was needed:
```
optimization:
    nncf:
        apply: true
        input_info:
            sample_size: null
```

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
