### PR TITLE
move threshold params to metric configuration callback

### DIFF
--- a/anomalib/config/config.py
+++ b/anomalib/config/config.py
@@ -166,7 +166,8 @@ def get_configurable_parameters(
     config = update_nncf_config(config)
 
     # thresholding
-    if "pixel_default" not in config.model.threshold.keys():
-        config.model.threshold.pixel_default = config.model.threshold.image_default
+    if "metrics" in config.keys():
+        if "pixel_default" not in config.metrics.threshold.keys():
+            config.metrics.threshold.pixel_default = config.metrics.threshold.image_default
 
     return config

--- a/anomalib/models/cflow/config.yaml
+++ b/anomalib/models/cflow/config.yaml
@@ -33,10 +33,6 @@ model:
     metric: pixel_AUROC
     mode: max
   normalization_method: min_max # options: [null, min_max, cdf]
-  threshold:
-    image_default: 0
-    pixel_default: 0
-    adaptive: true
 
 metrics:
   image:
@@ -45,6 +41,10 @@ metrics:
   pixel:
     - F1Score
     - AUROC
+  threshold:
+    image_default: 0
+    pixel_default: 0
+    adaptive: true
 
 project:
   seed: 0

--- a/anomalib/models/cflow/lightning_model.py
+++ b/anomalib/models/cflow/lightning_model.py
@@ -43,9 +43,6 @@ class Cflow(AnomalyModule):
 
     def __init__(
         self,
-        adaptive_threshold: bool,
-        default_image_threshold: float,
-        default_pixel_threshold: float,
         input_size: Tuple[int, int],
         backbone: str,
         layers: List[str],
@@ -56,11 +53,7 @@ class Cflow(AnomalyModule):
         clamp_alpha: float = 1.9,
         permute_soft: bool = False,
     ):
-        super().__init__(
-            adaptive_threshold=adaptive_threshold,
-            default_image_threshold=default_image_threshold,
-            default_pixel_threshold=default_pixel_threshold,
-        )
+        super().__init__()
         logger.info("Initializing Cflow Lightning model.")
 
         self.model: CflowModel = CflowModel(
@@ -177,9 +170,6 @@ class CflowLightning(Cflow):
 
     def __init__(self, hparams: Union[DictConfig, ListConfig]) -> None:
         super().__init__(
-            adaptive_threshold=hparams.model.threshold.adaptive,
-            default_image_threshold=hparams.model.threshold.image_default,
-            default_pixel_threshold=hparams.model.threshold.pixel_default,
             input_size=hparams.model.input_size,
             backbone=hparams.model.backbone,
             layers=hparams.model.layers,

--- a/anomalib/models/components/base/anomaly_module.py
+++ b/anomalib/models/components/base/anomaly_module.py
@@ -33,34 +33,19 @@ class AnomalyModule(pl.LightningModule, ABC):
     """AnomalyModule to train, validate, predict and test images.
 
     Acts as a base class for all the Anomaly Modules in the library.
-
-    Args:
-        adaptive_threshold (Optional[bool], optional): Boolean to automatically choose adaptive threshold.
-            Defaults to None.
-        default_image_threshold (Optional[float], optional): Manual default image threshold.
-            Defaults to None.
-        default_pixel_threshold (Optional[float], optional): Manaul default pixel threshold.
-            Defaults to None.
     """
 
-    def __init__(
-        self,
-        adaptive_threshold: Optional[bool] = None,
-        default_image_threshold: Optional[float] = None,
-        default_pixel_threshold: Optional[float] = None,
-    ):
+    def __init__(self):
         super().__init__()
         self.save_hyperparameters()
         self.model: nn.Module
         self.loss: Tensor
         self.callbacks: List[Callback]
 
-        self.adaptive_threshold = False if adaptive_threshold is None else adaptive_threshold
-        self.default_image_threshold = 0.0 if default_image_threshold is None else default_image_threshold
-        self.default_pixel_threshold = 0.0 if default_pixel_threshold is None else default_pixel_threshold
+        self.adaptive_threshold: bool
 
-        self.image_threshold = AdaptiveThreshold(self.default_image_threshold).cpu()
-        self.pixel_threshold = AdaptiveThreshold(self.default_pixel_threshold).cpu()
+        self.image_threshold = AdaptiveThreshold().cpu()
+        self.pixel_threshold = AdaptiveThreshold().cpu()
 
         self.training_distribution = AnomalyScoreDistribution().cpu()
         self.min_max = MinMax().cpu()

--- a/anomalib/models/dfkde/config.yaml
+++ b/anomalib/models/dfkde/config.yaml
@@ -23,14 +23,14 @@ model:
   threshold_steepness: 0.05
   threshold_offset: 12
   normalization_method: min_max # options: [null, min_max, cdf]
-  threshold:
-    image_default: 0
-    adaptive: true
 
 metrics:
   image:
     - F1Score
     - AUROC
+  threshold:
+    image_default: 0
+    adaptive: true
 
 project:
   seed: 42

--- a/anomalib/models/dfkde/lightning_model.py
+++ b/anomalib/models/dfkde/lightning_model.py
@@ -33,8 +33,6 @@ class Dfkde(AnomalyModule):
     """DFKDE: Deep Feature Kernel Density Estimation.
 
     Args:
-        adaptive_threshold (bool): Boolean to automatically choose adaptive threshold
-        default_image_threshold (float): Manual default image threshold
         backbone (str): Pre-trained model backbone.
         max_training_points (int, optional): Number of training points to fit the KDE model.
             Defaults to 40000.
@@ -48,8 +46,6 @@ class Dfkde(AnomalyModule):
 
     def __init__(
         self,
-        adaptive_threshold: bool,
-        default_image_threshold: float,
         backbone: str,
         max_training_points: int = 40000,
         pre_processing: str = "scale",
@@ -58,10 +54,7 @@ class Dfkde(AnomalyModule):
         threshold_offset: int = 12,
     ):
 
-        super().__init__(
-            adaptive_threshold=adaptive_threshold,
-            default_image_threshold=default_image_threshold,
-        )
+        super().__init__()
         logger.info("Initializing DFKDE Lightning model.")
 
         self.model = DfkdeModel(
@@ -132,8 +125,6 @@ class DfkdeLightning(Dfkde):
 
     def __init__(self, hparams: Union[DictConfig, ListConfig]) -> None:
         super().__init__(
-            adaptive_threshold=hparams.model.threshold.adaptive,
-            default_image_threshold=hparams.model.threshold.image_default,
             backbone=hparams.model.backbone,
             max_training_points=hparams.model.max_training_points,
             pre_processing=hparams.model.pre_processing,

--- a/anomalib/models/dfm/config.yaml
+++ b/anomalib/models/dfm/config.yaml
@@ -22,9 +22,6 @@ model:
   score_type: fre # nll: for Gaussian modeling, fre: pca feature reconstruction error
   project_path: ./results
   normalization_method: min_max # options: [null, min_max, cdf]
-  threshold:
-    image_default: 0
-    adaptive: true
 
 metrics:
   image:
@@ -33,6 +30,9 @@ metrics:
   pixel:
     - F1Score
     - AUROC
+  threshold:
+    image_default: 0
+    adaptive: true
 
 project:
   seed: 42

--- a/anomalib/models/dfm/lightning_model.py
+++ b/anomalib/models/dfm/lightning_model.py
@@ -34,8 +34,6 @@ class Dfm(AnomalyModule):
     """DFM: Deep Featured Kernel Density Estimation.
 
     Args:
-        adaptive_threshold (bool): Boolean to automatically choose adaptive threshold
-        default_image_threshold (float): Manual default image threshold
         backbone (str): Backbone CNN network
         layer (str): Layer to extract features from the backbone CNN
         pooling_kernel_size (int, optional): Kernel size to pool features extracted from the CNN.
@@ -48,18 +46,13 @@ class Dfm(AnomalyModule):
 
     def __init__(
         self,
-        adaptive_threshold: bool,
-        default_image_threshold: float,
         backbone: str,
         layer: str,
         pooling_kernel_size: int = 4,
         pca_level: float = 0.97,
         score_type: str = "fre",
     ):
-        super().__init__(
-            adaptive_threshold=adaptive_threshold,
-            default_image_threshold=default_image_threshold,
-        )
+        super().__init__()
         logger.info("Initializing DFKDE Lightning model.")
 
         self.model: DFMModel = DFMModel(
@@ -132,8 +125,6 @@ class DfmLightning(Dfm):
 
     def __init__(self, hparams: Union[DictConfig, ListConfig]) -> None:
         super().__init__(
-            adaptive_threshold=hparams.model.threshold.adaptive,
-            default_image_threshold=hparams.model.threshold.image_default,
             backbone=hparams.model.backbone,
             layer=hparams.model.layer,
             pooling_kernel_size=hparams.model.pooling_kernel_size,

--- a/anomalib/models/ganomaly/config.yaml
+++ b/anomalib/models/ganomaly/config.yaml
@@ -37,9 +37,6 @@ model:
   wadv: 1
   wcon: 50
   wenc: 1
-  threshold:
-    image_default: 0
-    adaptive: true
 
 metrics:
   image:
@@ -48,6 +45,9 @@ metrics:
   pixel:
     - F1Score
     - AUROC
+  threshold:
+    image_default: 0
+    adaptive: true
 
 project:
   seed: 0

--- a/anomalib/models/ganomaly/lightning_model.py
+++ b/anomalib/models/ganomaly/lightning_model.py
@@ -39,8 +39,6 @@ class Ganomaly(AnomalyModule):
     """PL Lightning Module for the GANomaly Algorithm.
 
     Args:
-        adaptive_threshold (bool): Boolean to automatically choose adaptive threshold
-        default_image_threshold (float): Manual default image threshold
         batch_size (int): Batch size.
         input_size (Tuple[int,int]): Input dimension.
         n_features (int): Number of features layers in the CNNs.
@@ -54,8 +52,6 @@ class Ganomaly(AnomalyModule):
 
     def __init__(
         self,
-        adaptive_threshold: bool,
-        default_image_threshold: float,
         batch_size: int,
         input_size: Tuple[int, int],
         n_features: int,
@@ -67,10 +63,7 @@ class Ganomaly(AnomalyModule):
         wenc: int = 1,
     ):
 
-        super().__init__(
-            adaptive_threshold=adaptive_threshold,
-            default_image_threshold=default_image_threshold,
-        )
+        super().__init__()
         logger.info("Initializing Ganomaly Lightning model.")
 
         self.model: GanomalyModel = GanomalyModel(
@@ -197,8 +190,6 @@ class GanomalyLightning(Ganomaly):
     def __init__(self, hparams: Union[DictConfig, ListConfig]) -> None:
 
         super().__init__(
-            adaptive_threshold=hparams.model.threshold.adaptive,
-            default_image_threshold=hparams.model.threshold.image_default,
             batch_size=hparams.dataset.train_batch_size,
             input_size=hparams.model.input_size,
             n_features=hparams.model.n_features,

--- a/anomalib/models/padim/config.yaml
+++ b/anomalib/models/padim/config.yaml
@@ -28,10 +28,6 @@ model:
     - layer2
     - layer3
   normalization_method: min_max # options: [none, min_max, cdf]
-  threshold:
-    image_default: 3
-    pixel_default: 3
-    adaptive: true
 
 metrics:
   image:
@@ -40,6 +36,10 @@ metrics:
   pixel:
     - F1Score
     - AUROC
+  threshold:
+    image_default: 3
+    pixel_default: 3
+    adaptive: true
 
 project:
   seed: 42

--- a/anomalib/models/padim/lightning_model.py
+++ b/anomalib/models/padim/lightning_model.py
@@ -38,9 +38,6 @@ class Padim(AnomalyModule):
     """PaDiM: a Patch Distribution Modeling Framework for Anomaly Detection and Localization.
 
     Args:
-        adaptive_threshold (bool): Boolean to automatically choose adaptive threshold
-        default_image_threshold (float): Manual default image threshold
-        default_pixel_threshold (float): Manaul default pixel threshold
         layers (List[str]): Layers to extract features from the backbone CNN
         input_size (Tuple[int, int]): Size of the model input.
         backbone (str): Backbone CNN network
@@ -48,18 +45,11 @@ class Padim(AnomalyModule):
 
     def __init__(
         self,
-        adaptive_threshold: bool,
-        default_image_threshold: float,
-        default_pixel_threshold: float,
         layers: List[str],
         input_size: Tuple[int, int],
         backbone: str,
     ):
-        super().__init__(
-            adaptive_threshold=adaptive_threshold,
-            default_image_threshold=default_image_threshold,
-            default_pixel_threshold=default_pixel_threshold,
-        )
+        super().__init__()
         logger.info("Initializing Padim Lightning model.")
 
         self.layers = layers
@@ -134,9 +124,6 @@ class PadimLightning(Padim):
 
     def __init__(self, hparams: Union[DictConfig, ListConfig]):
         super().__init__(
-            adaptive_threshold=hparams.model.threshold.adaptive,
-            default_image_threshold=hparams.model.threshold.image_default,
-            default_pixel_threshold=hparams.model.threshold.pixel_default,
             input_size=hparams.model.input_size,
             layers=hparams.model.layers,
             backbone=hparams.model.backbone,

--- a/anomalib/models/patchcore/config.yaml
+++ b/anomalib/models/patchcore/config.yaml
@@ -30,10 +30,6 @@ model:
   num_neighbors: 9
   weight_file: weights/model.ckpt
   normalization_method: min_max # options: [null, min_max, cdf]
-  threshold:
-    image_default: 0
-    pixel_default: 0
-    adaptive: true
 
 metrics:
   image:
@@ -42,6 +38,10 @@ metrics:
   pixel:
     - F1Score
     - AUROC
+  threshold:
+    image_default: 0
+    pixel_default: 0
+    adaptive: true
 
 project:
   seed: 0

--- a/anomalib/models/patchcore/lightning_model.py
+++ b/anomalib/models/patchcore/lightning_model.py
@@ -36,9 +36,6 @@ class Patchcore(AnomalyModule):
     """PatchcoreLightning Module to train PatchCore algorithm.
 
     Args:
-        adaptive_threshold (bool): Boolean to automatically choose adaptive threshold
-        default_image_threshold (float): Manual default image threshold
-        default_pixel_threshold (float): Manaul default pixel threshold
         input_size (Tuple[int, int]): Size of the model input.
         backbone (str): Backbone CNN network
         layers (List[str]): Layers to extract features from the backbone CNN
@@ -49,9 +46,6 @@ class Patchcore(AnomalyModule):
 
     def __init__(
         self,
-        adaptive_threshold: bool,
-        default_image_threshold: float,
-        default_pixel_threshold: float,
         input_size: Tuple[int, int],
         backbone: str,
         layers: List[str],
@@ -59,11 +53,7 @@ class Patchcore(AnomalyModule):
         num_neighbors: int = 9,
     ) -> None:
 
-        super().__init__(
-            adaptive_threshold=adaptive_threshold,
-            default_image_threshold=default_image_threshold,
-            default_pixel_threshold=default_pixel_threshold,
-        )
+        super().__init__()
         logger.info("Initializing Patchcore Lightning model.")
 
         self.model: PatchcoreModel = PatchcoreModel(
@@ -141,9 +131,6 @@ class PatchcoreLightning(Patchcore):
 
     def __init__(self, hparams) -> None:
         super().__init__(
-            adaptive_threshold=hparams.model.threshold.adaptive,
-            default_image_threshold=hparams.model.threshold.image_default,
-            default_pixel_threshold=hparams.model.threshold.pixel_default,
             input_size=hparams.model.input_size,
             backbone=hparams.model.backbone,
             layers=hparams.model.layers,

--- a/anomalib/models/stfpm/config.yaml
+++ b/anomalib/models/stfpm/config.yaml
@@ -36,10 +36,6 @@ model:
     metric: pixel_AUROC
     mode: max
   normalization_method: min_max # options: [null, min_max, cdf]
-  threshold:
-    image_default: 0
-    pixel_default: 0
-    adaptive: true
 
 metrics:
   image:
@@ -48,6 +44,10 @@ metrics:
   pixel:
     - F1Score
     - AUROC
+  threshold:
+    image_default: 0
+    pixel_default: 0
+    adaptive: true
 
 project:
   seed: 0

--- a/anomalib/models/stfpm/lightning_model.py
+++ b/anomalib/models/stfpm/lightning_model.py
@@ -39,9 +39,6 @@ class Stfpm(AnomalyModule):
     """PL Lightning Module for the STFPM algorithm.
 
     Args:
-        adaptive_threshold (bool): Boolean to automatically choose adaptive threshold
-        default_image_threshold (float): Manual default image threshold
-        default_pixel_threshold (float): Manaul default pixel threshold
         input_size (Tuple[int, int]): Size of the model input.
         backbone (str): Backbone CNN network
         layers (List[str]): Layers to extract features from the backbone CNN
@@ -49,19 +46,12 @@ class Stfpm(AnomalyModule):
 
     def __init__(
         self,
-        adaptive_threshold: bool,
-        default_image_threshold: float,
-        default_pixel_threshold: float,
         input_size: Tuple[int, int],
         backbone: str,
         layers: List[str],
     ):
 
-        super().__init__(
-            adaptive_threshold=adaptive_threshold,
-            default_image_threshold=default_image_threshold,
-            default_pixel_threshold=default_pixel_threshold,
-        )
+        super().__init__()
         logger.info("Initializing Stfpm Lightning model.")
 
         self.model = STFPMModel(
@@ -117,9 +107,6 @@ class StfpmLightning(Stfpm):
 
     def __init__(self, hparams: Union[DictConfig, ListConfig]) -> None:
         super().__init__(
-            adaptive_threshold=hparams.model.threshold.adaptive,
-            default_image_threshold=hparams.model.threshold.image_default,
-            default_pixel_threshold=hparams.model.threshold.pixel_default,
             input_size=hparams.model.input_size,
             backbone=hparams.model.backbone,
             layers=hparams.model.layers,

--- a/anomalib/utils/callbacks/__init__.py
+++ b/anomalib/utils/callbacks/__init__.py
@@ -66,7 +66,19 @@ def get_callbacks(config: Union[ListConfig, DictConfig]) -> List[Callback]:
     # Add metric configuration to the model via MetricsConfigurationCallback
     image_metric_names = config.metrics.image if "image" in config.metrics.keys() else None
     pixel_metric_names = config.metrics.pixel if "pixel" in config.metrics.keys() else None
-    metrics_callback = MetricsConfigurationCallback(image_metric_names, pixel_metric_names)
+    image_threshold = (
+        config.metrics.threshold.image_default if "image_default" in config.metrics.threshold.keys() else None
+    )
+    pixel_threshold = (
+        config.metrics.threshold.pixel_default if "pixel_default" in config.metrics.threshold.keys() else None
+    )
+    metrics_callback = MetricsConfigurationCallback(
+        config.metrics.threshold.adaptive,
+        image_threshold,
+        pixel_threshold,
+        image_metric_names,
+        pixel_metric_names,
+    )
     callbacks.append(metrics_callback)
 
     if "weight_file" in config.model.keys():

--- a/anomalib/utils/metrics/adaptive_threshold.py
+++ b/anomalib/utils/metrics/adaptive_threshold.py
@@ -10,7 +10,7 @@ class AdaptiveThreshold(Metric):
     predicted anomaly scores.
     """
 
-    def __init__(self, default_value: float, **kwargs):
+    def __init__(self, default_value: float = 0.5, **kwargs):
         super().__init__(**kwargs)
 
         self.precision_recall_curve = PrecisionRecallCurve(num_classes=1, compute_on_step=False)

--- a/tests/pre_merge/utils/callbacks/normalization_callback/test_normalization_callback.py
+++ b/tests/pre_merge/utils/callbacks/normalization_callback/test_normalization_callback.py
@@ -23,7 +23,7 @@ def test_normalizer(path=get_dataset_path(), category="shapes"):
     config = get_configurable_parameters(config_path="anomalib/models/padim/config.yaml")
     config.dataset.path = path
     config.dataset.category = category
-    config.model.threshold.adaptive = True
+    config.metrics.threshold.adaptive = True
     config.project.log_images_to = []
     config.metrics.image = ["F1Score", "AUROC"]
 

--- a/tests/pre_merge/utils/callbacks/visualizer_callback/dummy_lightning_model.py
+++ b/tests/pre_merge/utils/callbacks/visualizer_callback/dummy_lightning_model.py
@@ -47,11 +47,7 @@ class DummyModule(AnomalyModule):
     """A dummy model which calls visualizer callback on fake images and masks."""
 
     def __init__(self, hparams: Union[DictConfig, ListConfig]):
-        super().__init__(
-            adaptive_threshold=hparams.model.threshold.adaptive,
-            default_image_threshold=hparams.model.threshold.image_default,
-            default_pixel_threshold=hparams.model.threshold.pixel_default,
-        )
+        super().__init__()
         self.model = DummyModel()
         self.task = "segmentation"
         self.callbacks = [

--- a/tests/pre_merge/utils/metrics/test_adaptive_threshold.py
+++ b/tests/pre_merge/utils/metrics/test_adaptive_threshold.py
@@ -51,15 +51,15 @@ def test_non_adaptive_threshold():
     config = get_test_configurable_parameters(config_path="anomalib/models/padim/config.yaml")
 
     config.model.normalization_method = "none"
-    config.model.threshold.adaptive = False
+    config.metrics.threshold.adaptive = False
     config.trainer.fast_dev_run = True
     config.metrics.image = ["F1Score"]
     config.metrics.pixel = ["F1Score"]
 
     image_threshold = random.random()
     pixel_threshold = random.random()
-    config.model.threshold.image_default = image_threshold
-    config.model.threshold.pixel_default = pixel_threshold
+    config.metrics.threshold.image_default = image_threshold
+    config.metrics.threshold.pixel_default = pixel_threshold
 
     model = get_model(config)
     datamodule = get_datamodule(config)


### PR DESCRIPTION
# Description
This PR moves the thresholding parameters outside of the model parameters section. This also removes the thresholding-related arguments from the base class, which leads to a cleaner implementation of that class. The responsibility of configuring the threshold metric classes is moved from the base task to the metrics callback.

## Changes
- [x] Refactor
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
