### PR TITLE
fix too many open images warning

### DIFF
--- a/anomalib/post_processing/visualizer.py
+++ b/anomalib/post_processing/visualizer.py
@@ -68,7 +68,6 @@ class Visualizer:
 
     def show(self):
         """Show image on a matplotlib figure."""
-        self.generate()
         self.figure.show()
 
     def save(self, filename: Path):
@@ -77,7 +76,6 @@ class Visualizer:
         Args:
           filename (Path): Filename to save image
         """
-        self.generate()
         filename.parent.mkdir(parents=True, exist_ok=True)
         self.figure.savefig(filename, dpi=100)
 


### PR DESCRIPTION
# Description
This PR fixes a bug that caused too many matplotlib figures to be retained in memory. `visualizer.generate()` was unintentionally called twice for every image, causing the number of open images to build up as the test loop progressed. Fixed by leaving the responsibility of calling `visualizer.generate()` to the callback class instead of the visualizer itself.

Note: Since this bug affected development, I target development in this PR. Will rebase the feature branch to pull in the changes there.

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
