### PR TITLE
🚀 Set pylint version in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands = flake8 anomalib --exclude=anomalib/models/components/freia
 skip_install = true
 basepython = python3
 deps =
-    pylint
+    pylint<2.14
     -r{toxinidir}/requirements/base.txt
 commands = pylint anomalib --rcfile=tox.ini --ignore=anomalib/models/components/freia/
 


### PR DESCRIPTION
# Description

- There is an issue in `pylint==2.14.0` which incorrectly parses `tox.ini`. The idea is to use a lower version of pylint till versions >=2.14.1 are available in the pip channel.