### PR TITLE
Add metrics configuration callback to benchmarking

### DIFF
--- a/anomalib/utils/sweep/helpers/callbacks.py
+++ b/anomalib/utils/sweep/helpers/callbacks.py
@@ -15,14 +15,16 @@
 # and limitations under the License.
 
 
-from typing import List
+from typing import List, Union
 
+from omegaconf import DictConfig, ListConfig
 from pytorch_lightning import Callback
 
+from anomalib.utils.callbacks import MetricsConfigurationCallback
 from anomalib.utils.callbacks.timer import TimerCallback
 
 
-def get_sweep_callbacks() -> List[Callback]:
+def get_sweep_callbacks(config: Union[ListConfig, DictConfig]) -> List[Callback]:
     """Gets callbacks relevant to sweep.
 
     Args:
@@ -32,5 +34,22 @@ def get_sweep_callbacks() -> List[Callback]:
         List[Callback]: List of callbacks
     """
     callbacks: List[Callback] = [TimerCallback()]
+    # Add metric configuration to the model via MetricsConfigurationCallback
+    image_metric_names = config.metrics.image if "image" in config.metrics.keys() else None
+    pixel_metric_names = config.metrics.pixel if "pixel" in config.metrics.keys() else None
+    image_threshold = (
+        config.metrics.threshold.image_default if "image_default" in config.metrics.threshold.keys() else None
+    )
+    pixel_threshold = (
+        config.metrics.threshold.pixel_default if "pixel_default" in config.metrics.threshold.keys() else None
+    )
+    metrics_callback = MetricsConfigurationCallback(
+        config.metrics.threshold.adaptive,
+        image_threshold,
+        pixel_threshold,
+        image_metric_names,
+        pixel_metric_names,
+    )
+    callbacks.append(metrics_callback)
 
     return callbacks

--- a/tools/benchmarking/benchmark.py
+++ b/tools/benchmarking/benchmark.py
@@ -100,7 +100,7 @@ def get_single_model_metrics(model_config: Union[DictConfig, ListConfig], openvi
         datamodule = get_datamodule(model_config)
         model = get_model(model_config)
 
-        callbacks = get_sweep_callbacks()
+        callbacks = get_sweep_callbacks(model_config)
 
         trainer = Trainer(**model_config.trainer, logger=None, callbacks=callbacks)
 


### PR DESCRIPTION
# Description

Currently benchmarking script fails which also breaks the test in nightly

- Add MetricsConfigurationCallback to benchmarking callbacks.

Note: This adds duplicate lines from get_callbacks used in train and test to benchmark utils.

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
