### PR TITLE
🏷️ Refactor Datamodule names 

### DIFF
--- a/anomalib/data/__init__.py
+++ b/anomalib/data/__init__.py
@@ -22,7 +22,7 @@ from pytorch_lightning import LightningDataModule
 from .btech import BTechDataModule
 from .folder import FolderDataModule
 from .inference import InferenceDataset
-from .mvtec import MVTecDataModule
+from .mvtec import MVTec
 
 
 def get_datamodule(config: Union[DictConfig, ListConfig]) -> LightningDataModule:
@@ -37,7 +37,7 @@ def get_datamodule(config: Union[DictConfig, ListConfig]) -> LightningDataModule
     datamodule: LightningDataModule
 
     if config.dataset.format.lower() == "mvtec":
-        datamodule = MVTecDataModule(
+        datamodule = MVTec(
             # TODO: Remove config values. IAAALD-211
             root=config.dataset.path,
             category=config.dataset.category,
@@ -100,5 +100,5 @@ __all__ = [
     "BTechDataModule",
     "FolderDataModule",
     "InferenceDataset",
-    "MVTecDataModule",
+    "MVTec",
 ]

--- a/anomalib/data/__init__.py
+++ b/anomalib/data/__init__.py
@@ -19,7 +19,7 @@ from typing import Union
 from omegaconf import DictConfig, ListConfig
 from pytorch_lightning import LightningDataModule
 
-from .btech import BTechDataModule
+from .btech import BTech
 from .folder import FolderDataModule
 from .inference import InferenceDataset
 from .mvtec import MVTec
@@ -52,7 +52,7 @@ def get_datamodule(config: Union[DictConfig, ListConfig]) -> LightningDataModule
             create_validation_set=config.dataset.create_validation_set,
         )
     elif config.dataset.format.lower() == "btech":
-        datamodule = BTechDataModule(
+        datamodule = BTech(
             # TODO: Remove config values. IAAALD-211
             root=config.dataset.path,
             category=config.dataset.category,
@@ -97,7 +97,7 @@ def get_datamodule(config: Union[DictConfig, ListConfig]) -> LightningDataModule
 
 __all__ = [
     "get_datamodule",
-    "BTechDataModule",
+    "BTech",
     "FolderDataModule",
     "InferenceDataset",
     "MVTec",

--- a/anomalib/data/__init__.py
+++ b/anomalib/data/__init__.py
@@ -20,7 +20,7 @@ from omegaconf import DictConfig, ListConfig
 from pytorch_lightning import LightningDataModule
 
 from .btech import BTech
-from .folder import FolderDataModule
+from .folder import Folder
 from .inference import InferenceDataset
 from .mvtec import MVTec
 
@@ -67,7 +67,7 @@ def get_datamodule(config: Union[DictConfig, ListConfig]) -> LightningDataModule
             create_validation_set=config.dataset.create_validation_set,
         )
     elif config.dataset.format.lower() == "folder":
-        datamodule = FolderDataModule(
+        datamodule = Folder(
             root=config.dataset.path,
             normal_dir=config.dataset.normal_dir,
             abnormal_dir=config.dataset.abnormal_dir,
@@ -98,7 +98,7 @@ def get_datamodule(config: Union[DictConfig, ListConfig]) -> LightningDataModule
 __all__ = [
     "get_datamodule",
     "BTech",
-    "FolderDataModule",
+    "Folder",
     "InferenceDataset",
     "MVTec",
 ]

--- a/anomalib/data/btech.py
+++ b/anomalib/data/btech.py
@@ -141,7 +141,7 @@ def make_btech_dataset(
     return samples
 
 
-class BTech(VisionDataset):
+class BTechDataset(VisionDataset):
     """BTech PyTorch Dataset."""
 
     def __init__(
@@ -166,10 +166,10 @@ class BTech(VisionDataset):
             create_validation_set: Create a validation subset in addition to the train and test subsets
 
         Examples:
-            >>> from anomalib.data.btech import BTech
+            >>> from anomalib.data.btech import BTechDataset
             >>> from anomalib.data.transforms import PreProcessor
             >>> pre_process = PreProcessor(image_size=256)
-            >>> dataset = BTech(
+            >>> dataset = BTechDataset(
             ...     root='./datasets/BTech',
             ...     category='leather',
             ...     pre_process=pre_process,
@@ -257,7 +257,7 @@ class BTech(VisionDataset):
         return item
 
 
-class BTechDataModule(LightningDataModule):
+class BTech(LightningDataModule):
     """BTechDataModule Lightning Data Module."""
 
     def __init__(
@@ -291,8 +291,8 @@ class BTechDataModule(LightningDataModule):
             create_validation_set: Create a validation subset in addition to the train and test subsets
 
         Examples
-            >>> from anomalib.data import BTechDataModule
-            >>> datamodule = BTechDataModule(
+            >>> from anomalib.data import BTech
+            >>> datamodule = BTech(
             ...     root="./datasets/BTech",
             ...     category="leather",
             ...     image_size=256,
@@ -398,7 +398,7 @@ class BTechDataModule(LightningDataModule):
         """
         logger.info("Setting up train, validation, test and prediction datasets.")
         if stage in (None, "fit"):
-            self.train_data = BTech(
+            self.train_data = BTechDataset(
                 root=self.root,
                 category=self.category,
                 pre_process=self.pre_process_train,
@@ -409,7 +409,7 @@ class BTechDataModule(LightningDataModule):
             )
 
         if self.create_validation_set:
-            self.val_data = BTech(
+            self.val_data = BTechDataset(
                 root=self.root,
                 category=self.category,
                 pre_process=self.pre_process_val,
@@ -419,7 +419,7 @@ class BTechDataModule(LightningDataModule):
                 create_validation_set=self.create_validation_set,
             )
 
-        self.test_data = BTech(
+        self.test_data = BTechDataset(
             root=self.root,
             category=self.category,
             pre_process=self.pre_process_val,

--- a/anomalib/data/folder.py
+++ b/anomalib/data/folder.py
@@ -301,7 +301,7 @@ class FolderDataset(Dataset):
         return item
 
 
-class FolderDataModule(LightningDataModule):
+class Folder(LightningDataModule):
     """Folder Lightning Data Module."""
 
     def __init__(
@@ -359,8 +359,8 @@ class FolderDataModule(LightningDataModule):
 
         Examples:
             Assume that we use Folder Dataset for the MVTec/bottle/broken_large category. We would do:
-            >>> from anomalib.data import FolderDataModule
-            >>> datamodule = FolderDataModule(
+            >>> from anomalib.data import Folder
+            >>> datamodule = Folder(
             ...     root="./datasets/MVTec/bottle/test",
             ...     normal="good",
             ...     abnormal="broken_large",
@@ -379,7 +379,7 @@ class FolderDataModule(LightningDataModule):
             The dataset expects that mask annotation filenames must be same as the original filename.
             To this end, we modified mask filenames in MVTec AD bottle category.
             Now we could try folder data module using the mvtec bottle broken large category
-            >>> datamodule = FolderDataModule(
+            >>> datamodule = Folder(
             ...     root="./datasets/bottle/test",
             ...     normal="good",
             ...     abnormal="broken_large",
@@ -401,7 +401,7 @@ class FolderDataModule(LightningDataModule):
             By default, Folder Data Module does not create a validation set. If a validation set
             is needed it could be set as follows:
 
-            >>> datamodule = FolderDataModule(
+            >>> datamodule = Folder(
             ...     root="./datasets/bottle/test",
             ...     normal="good",
             ...     abnormal="broken_large",

--- a/anomalib/data/mvtec.py
+++ b/anomalib/data/mvtec.py
@@ -164,7 +164,7 @@ def make_mvtec_dataset(
     return samples
 
 
-class MVTec(VisionDataset):
+class MVTecDataset(VisionDataset):
     """MVTec AD PyTorch Dataset."""
 
     def __init__(
@@ -189,10 +189,10 @@ class MVTec(VisionDataset):
             create_validation_set: Create a validation subset in addition to the train and test subsets
 
         Examples:
-            >>> from anomalib.data.mvtec import MVTec
+            >>> from anomalib.data.mvtec import MVTecDataset
             >>> from anomalib.data.transforms import PreProcessor
             >>> pre_process = PreProcessor(image_size=256)
-            >>> dataset = MVTec(
+            >>> dataset = MVTecDataset(
             ...     root='./datasets/MVTec',
             ...     category='leather',
             ...     pre_process=pre_process,
@@ -280,7 +280,7 @@ class MVTec(VisionDataset):
         return item
 
 
-class MVTecDataModule(LightningDataModule):
+class MVTec(LightningDataModule):
     """MVTec AD Lightning Data Module."""
 
     def __init__(
@@ -314,8 +314,8 @@ class MVTecDataModule(LightningDataModule):
             create_validation_set: Create a validation subset in addition to the train and test subsets
 
         Examples
-            >>> from anomalib.data import MVTecDataModule
-            >>> datamodule = MVTecDataModule(
+            >>> from anomalib.data import MVTec
+            >>> datamodule = MVTec(
             ...     root="./datasets/MVTec",
             ...     category="leather",
             ...     image_size=256,
@@ -404,7 +404,7 @@ class MVTecDataModule(LightningDataModule):
         """
         logger.info("Setting up train, validation, test and prediction datasets.")
         if stage in (None, "fit"):
-            self.train_data = MVTec(
+            self.train_data = MVTecDataset(
                 root=self.root,
                 category=self.category,
                 pre_process=self.pre_process_train,
@@ -415,7 +415,7 @@ class MVTecDataModule(LightningDataModule):
             )
 
         if self.create_validation_set:
-            self.val_data = MVTec(
+            self.val_data = MVTecDataset(
                 root=self.root,
                 category=self.category,
                 pre_process=self.pre_process_val,
@@ -425,7 +425,7 @@ class MVTecDataModule(LightningDataModule):
                 create_validation_set=self.create_validation_set,
             )
 
-        self.test_data = MVTec(
+        self.test_data = MVTecDataset(
             root=self.root,
             category=self.category,
             pre_process=self.pre_process_val,

--- a/anomalib/models/draem/config.yaml
+++ b/anomalib/models/draem/config.yaml
@@ -45,8 +45,11 @@ metrics:
 project:
   seed: 42
   path: ./results
-  log_images_to: ["local"]
-  logger: false # options: [tensorboard, wandb, csv] or combinations.
+
+logging:
+  log_images_to: ["local"] # options: [wandb, tensorboard, local]. Make sure you also set logger with using wandb or tensorboard.
+  logger: [] # options: [tensorboard, wandb, csv] or combinations.
+  log_graph: false # Logs the model graph to respective logger.
 
 optimization:
   openvino:

--- a/anomalib/models/fastflow/config.yaml
+++ b/anomalib/models/fastflow/config.yaml
@@ -47,10 +47,13 @@ metrics:
     adaptive: true
 
 project:
-  seed: 0
+  seed: 42
   path: ./results
-  log_images_to: [local]
-  logger: false # options: [tensorboard, wandb, csv] or combinations.
+
+logging:
+  log_images_to: ["local"] # options: [wandb, tensorboard, local]. Make sure you also set logger with using wandb or tensorboard.
+  logger: [] # options: [tensorboard, wandb, csv] or combinations.
+  log_graph: false # Logs the model graph to respective logger.
 
 # PL Trainer Args. Don't add extra parameter here.
 trainer:

--- a/tests/pre_merge/datasets/test_dataset.py
+++ b/tests/pre_merge/datasets/test_dataset.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from anomalib.config import update_input_size_config
-from anomalib.data import BTechDataModule, FolderDataModule, MVTec, get_datamodule
+from anomalib.data import BTech, FolderDataModule, MVTec, get_datamodule
 from anomalib.pre_processing.transforms import Denormalize, ToNumpy
 from tests.helpers.config import get_test_configurable_parameters
 from tests.helpers.dataset import TestDataset, get_dataset_path
@@ -31,7 +31,7 @@ def mvtec_data_module():
 @pytest.fixture(autouse=True)
 def btech_data_module():
     """Create BTech Data Module."""
-    datamodule = BTechDataModule(
+    datamodule = BTech(
         root=get_dataset_path(dataset="BTech"),
         category="01",
         image_size=(256, 256),

--- a/tests/pre_merge/datasets/test_dataset.py
+++ b/tests/pre_merge/datasets/test_dataset.py
@@ -6,12 +6,7 @@ import numpy as np
 import pytest
 
 from anomalib.config import update_input_size_config
-from anomalib.data import (
-    BTechDataModule,
-    FolderDataModule,
-    MVTecDataModule,
-    get_datamodule,
-)
+from anomalib.data import BTechDataModule, FolderDataModule, MVTec, get_datamodule
 from anomalib.pre_processing.transforms import Denormalize, ToNumpy
 from tests.helpers.config import get_test_configurable_parameters
 from tests.helpers.dataset import TestDataset, get_dataset_path
@@ -19,7 +14,7 @@ from tests.helpers.dataset import TestDataset, get_dataset_path
 
 @pytest.fixture(autouse=True)
 def mvtec_data_module():
-    datamodule = MVTecDataModule(
+    datamodule = MVTec(
         root=get_dataset_path(dataset="MVTec"),
         category="leather",
         image_size=(256, 256),

--- a/tests/pre_merge/datasets/test_dataset.py
+++ b/tests/pre_merge/datasets/test_dataset.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from anomalib.config import update_input_size_config
-from anomalib.data import BTech, FolderDataModule, MVTec, get_datamodule
+from anomalib.data import BTech, Folder, MVTec, get_datamodule
 from anomalib.pre_processing.transforms import Denormalize, ToNumpy
 from tests.helpers.config import get_test_configurable_parameters
 from tests.helpers.dataset import TestDataset, get_dataset_path
@@ -49,7 +49,7 @@ def btech_data_module():
 def folder_data_module():
     """Create Folder Data Module."""
     root = get_dataset_path(dataset="bottle")
-    datamodule = FolderDataModule(
+    datamodule = Folder(
         root=root,
         normal_dir="good",
         abnormal_dir="broken_large",


### PR DESCRIPTION
# Description

- This PR refactors the name of the datamodules. This will be one of the basis of the Anomalib CLI. For example `MVTecDataModule` has been renamed to `MVTec`. This because Anomalib CLI will be able to choose the data from the CLI such as `python train.py --data MVTec`. 

## Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
