### PR TITLE
🚚 Move logging from train.py to the getter functions

### DIFF
--- a/anomalib/data/__init__.py
+++ b/anomalib/data/__init__.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
+import logging
 from typing import Union
 
 from omegaconf import DictConfig, ListConfig
@@ -23,6 +24,8 @@ from .btech import BTech
 from .folder import Folder
 from .inference import InferenceDataset
 from .mvtec import MVTec
+
+logger = logging.getLogger(__name__)
 
 
 def get_datamodule(config: Union[DictConfig, ListConfig]) -> LightningDataModule:
@@ -34,6 +37,8 @@ def get_datamodule(config: Union[DictConfig, ListConfig]) -> LightningDataModule
     Returns:
         PyTorch Lightning DataModule
     """
+    logger.info("Loading the datamodule")
+
     datamodule: LightningDataModule
 
     if config.dataset.format.lower() == "mvtec":

--- a/anomalib/models/__init__.py
+++ b/anomalib/models/__init__.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
+import logging
 import os
 from importlib import import_module
 from typing import List, Union
@@ -22,6 +23,8 @@ from omegaconf import DictConfig, ListConfig
 from torch import load
 
 from anomalib.models.components import AnomalyModule
+
+logger = logging.getLogger(__name__)
 
 
 def _snake_to_pascal_case(model_name: str) -> str:
@@ -54,6 +57,8 @@ def get_model(config: Union[DictConfig, ListConfig]) -> AnomalyModule:
     Returns:
         AnomalyModule: Anomaly Model
     """
+    logger.info("Loading the model.")
+
     model_list: List[str] = [
         "cflow",
         "dfkde",

--- a/anomalib/utils/callbacks/__init__.py
+++ b/anomalib/utils/callbacks/__init__.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
+import logging
 import os
 import warnings
 from importlib import import_module
@@ -41,6 +42,9 @@ __all__ = [
 ]
 
 
+logger = logging.getLogger(__name__)
+
+
 def get_callbacks(config: Union[ListConfig, DictConfig]) -> List[Callback]:
     """Return base callbacks for all the lightning models.
 
@@ -50,6 +54,8 @@ def get_callbacks(config: Union[ListConfig, DictConfig]) -> List[Callback]:
     Return:
         (List[Callback]): List of callbacks.
     """
+    logger.info("Loading the callbacks")
+
     callbacks: List[Callback] = []
 
     monitor_metric = None if "early_stopping" not in config.model.keys() else config.model.early_stopping.metric

--- a/anomalib/utils/loggers/__init__.py
+++ b/anomalib/utils/loggers/__init__.py
@@ -35,6 +35,9 @@ __all__ = [
 AVAILABLE_LOGGERS = ["tensorboard", "wandb", "csv"]
 
 
+logger = logging.getLogger(__name__)
+
+
 class UnknownLogger(Exception):
     """This is raised when the logger option in `config.yaml` file is set incorrectly."""
 
@@ -75,6 +78,7 @@ def get_experiment_logger(
     Returns:
         Union[LightningLoggerBase, Iterable[LightningLoggerBase], bool]: Logger
     """
+    logger.info("Loading the experiment logger(s)")
 
     # TODO remove when logger is deprecated from project
     if "logger" in config.project.keys():
@@ -95,8 +99,8 @@ def get_experiment_logger(
     if isinstance(config.logging.logger, str):
         config.logging.logger = [config.logging.logger]
 
-    for logger in config.logging.logger:
-        if logger == "tensorboard":
+    for experiment_logger in config.logging.logger:
+        if experiment_logger == "tensorboard":
             logger_list.append(
                 AnomalibTensorBoardLogger(
                     name="Tensorboard Logs",
@@ -104,7 +108,7 @@ def get_experiment_logger(
                     log_graph=config.logging.log_graph,
                 )
             )
-        elif logger == "wandb":
+        elif experiment_logger == "wandb":
             wandb_logdir = os.path.join(config.project.path, "logs")
             os.makedirs(wandb_logdir, exist_ok=True)
             name = (
@@ -119,7 +123,7 @@ def get_experiment_logger(
                     save_dir=wandb_logdir,
                 )
             )
-        elif logger == "csv":
+        elif experiment_logger == "csv":
             logger_list.append(CSVLogger(save_dir=os.path.join(config.project.path, "logs")))
         else:
             raise UnknownLogger(

--- a/tools/train.py
+++ b/tools/train.py
@@ -64,23 +64,16 @@ def train():
     args = get_args()
     configure_logger(level=args.log_level)
 
+    if args.log_level == "ERROR":
+        warnings.filterwarnings("ignore")
+
     config = get_configurable_parameters(model_name=args.model, config_path=args.config)
     if config.project.seed != 0:
         seed_everything(config.project.seed)
 
-    if args.log_level == "ERROR":
-        warnings.filterwarnings("ignore")
-
-    logger.info("Loading the datamodule")
     datamodule = get_datamodule(config)
-
-    logger.info("Loading the model.")
     model = get_model(config)
-
-    logger.info("Loading the experiment logger(s)")
     experiment_logger = get_experiment_logger(config)
-
-    logger.info("Loading the callbacks")
     callbacks = get_callbacks(config)
 
     trainer = Trainer(**config.trainer, logger=experiment_logger, callbacks=callbacks)


### PR DESCRIPTION
# Description

- This PR moves the logging info from `train.py` to the corresponding getter functions. This way, `train.py` entrypoint looks cleaner. Also, everytime the getter functions are called, the loggers log the information.

## Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
