### PR TITLE
Add encoding to LONG_DESCRIPTION in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ def get_required_packages(requirement_files: List[str]) -> List[str]:
 
 
 VERSION = get_version()
-LONG_DESCRIPTION = (Path(__file__).parent / "README.md").read_text()
+LONG_DESCRIPTION = (Path(__file__).parent / "README.md").read_text(encoding="utf8")
 INSTALL_REQUIRES = get_required_packages(requirement_files=["base"])
 EXTRAS_REQUIRE = {
     "dev": get_required_packages(requirement_files=["dev", "docs"]),


### PR DESCRIPTION
# Description

> When trying to install anomalib locally, as described in the readme.md, using pip install -e ., the command fails.
This happens, because in setup.py, the content of the readme is read into the LONG_DESCRIPTION, without specifying the encoding used.

- Fixes #407 

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
