### PR TITLE
Remove the redundant `loss_val`

### DIFF
--- a/anomalib/models/stfpm/lightning_model.py
+++ b/anomalib/models/stfpm/lightning_model.py
@@ -56,7 +56,6 @@ class Stfpm(AnomalyModule):
             layers=layers,
         )
         self.loss = STFPMLoss()
-        self.loss_val = 0
 
     def training_step(self, batch, _):  # pylint: disable=arguments-differ
         """Training Step of STFPM.
@@ -72,8 +71,7 @@ class Stfpm(AnomalyModule):
         """
         self.model.teacher_model.eval()
         teacher_features, student_features = self.model.forward(batch["image"])
-        loss = self.loss_val + self.loss(teacher_features, student_features)
-        self.loss_val = 0
+        loss = self.loss(teacher_features, student_features)
         return {"loss": loss}
 
     def validation_step(self, batch, _):  # pylint: disable=arguments-differ


### PR DESCRIPTION
# Description

- Currently the loss in STFPM is computed as follows : `loss = self.loss_val + self.loss(teacher_features, student_features)`. However, `self.loss_val` is always zero and adds no value. This PR therefore removes it from the computation.

- Fixes #421 

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
