### PR TITLE
Fix visualizer for `classification`, `mode=simple`

### DIFF
--- a/anomalib/post_processing/visualizer.py
+++ b/anomalib/post_processing/visualizer.py
@@ -158,9 +158,9 @@ class Visualizer:
             return (visualization * 255).astype(np.uint8)
         if self.task == "classification":
             if image_result.pred_label:
-                image_classified = add_anomalous_label(image_result.heat_map, image_result.pred_score)
+                image_classified = add_anomalous_label(image_result.image, image_result.pred_score)
             else:
-                image_classified = add_normal_label(image_result.heat_map, 1 - image_result.pred_score)
+                image_classified = add_normal_label(image_result.image, 1 - image_result.pred_score)
             return image_classified
         raise ValueError(f"Unknown task type: {self.task}")
 

--- a/tests/pre_merge/post_processing/test_visualizer.py
+++ b/tests/pre_merge/post_processing/test_visualizer.py
@@ -68,4 +68,4 @@ class TestVisualizer:
                 dataset_task=task,
                 visualizer_mode=mode,
             )[1:]
-            trainer.test(model=model, datamodule=datamodule)[0]
+            trainer.test(model=model, datamodule=datamodule)


### PR DESCRIPTION
# Description

- Provide a summary of the modification as well as the issue that has been resolved. List any dependencies that this modification necessitates.
  - Fix Visualizer for AD-only methods by referring to `image_result.image` instead of `image_result.heat_map` for `task==classification` since AD-only methods don't produce heat-maps.
  - Add integration test for `AnomalyModule`/`Visualizer`, where we test that both AD-only and segmentation modules work with Visualizers in all combinations of `task` and `mode`

- Fixes #441

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
