### PR TITLE
Move configuration from tox to pyproject

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,14 +15,12 @@ repos:
     rev: 22.6.0
     hooks:
       - id: black
-        args: [--line-length, "120"]
 
   # python import sorting
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1
     hooks:
       - id: isort
-        args: ["--profile", "black"]
 
   # yaml formatting
   - repo: https://github.com/pre-commit/mirrors-prettier
@@ -36,7 +34,7 @@ repos:
     rev: 4.0.1
     hooks:
       - id: flake8
-        args: [--config=tox.ini]
+        args: ["--max-line-length=120", "--ignore=E203,W503"]
         exclude: "tests|anomalib/models/components/freia"
 
   # python linting
@@ -45,7 +43,7 @@ repos:
     hooks:
       - id: pylint
         name: pylint
-        entry: pylint --score=no --rcfile=tox.ini
+        entry: pylint --score=no
         language: system
         types: [python]
         exclude: "tests|docs|anomalib/models/components/freia"
@@ -55,7 +53,6 @@ repos:
     rev: "v0.971"
     hooks:
       - id: mypy
-        args: [--config-file=tox.ini]
         additional_dependencies: [types-PyYAML]
         exclude: "tests|anomalib/models/components/freia"
 
@@ -63,11 +60,11 @@ repos:
     rev: 6.1.1
     hooks:
       - id: pydocstyle
+        additional_dependencies: [toml]
         name: pydocstyle
         entry: pydocstyle
         language: python
         types: [python]
-        args: [--config=tox.ini]
         exclude: "tests|docs|anomalib/models/components/freia"
 
   # notebooks.
@@ -77,4 +74,5 @@ repos:
       - id: nbqa-black
       - id: nbqa-isort
       - id: nbqa-flake8
+        args: ["--max-line-length=120", "--ignore=E203,W503"]
       - id: nbqa-pylint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,12 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # SETUP CONFIGURATION.                                                        #
-# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 [build-system]
 requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# ISORT CONFIGURATION.
-# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# ISORT CONFIGURATION.                                                        #
 [tool.isort]
 profile = "black"
 known_first_party = "wandb"
@@ -16,8 +14,7 @@ sections = ['FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER']
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# BLACK CONFIGURATION
-# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# BLACK CONFIGURATION                                                         #
 [tool.black]
 line-length = 120
 
@@ -28,7 +25,6 @@ max-line-length = 120
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # PYLINT CONFIGURATION                                                        #
-# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 [tool.pylint.main]
 extension-pkg-whitelist = "cv2"
 ignore = ["tests", "docs", "anomalib/models/components/freia"]
@@ -65,7 +61,6 @@ min-similarity-lines = 5
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # MYPY CONFIGURATION.                                                         #
-# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 [tool.mypy]
 ignore_missing_imports = true
 show_error_codes = true
@@ -84,7 +79,6 @@ follow_imports_for_stubs = true
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # COVERAGE CONFIGURATION                                                      #
-# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 [tool.coverage.report]
 exclude_lines = [
     "except ImportError",
@@ -111,6 +105,5 @@ ignore = [
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # NBQA CONFIGURATION                                                          #
-# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 [tool.nbqa.addopts]
 pylint = ["--disable=C0103,C0114,C0116,E0401,R0801,W0106"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,15 +2,106 @@
 requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"
 
+#
+# ISORT Configuration.
 [tool.isort]
 profile = "black"
 known_first_party = "wandb"
 sections = ['FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER']
 
+#
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# BLACK CONFIGURATION
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 [tool.black]
 line-length = 120
 
-[tool.nbqa.addopts]
-pylint = [
-    "--disable=C0103,C0114,C0116,E0401,R0801,W0106"
+[tool.flake8]
+ignore = ["E203", "W503"]
+max-line-length = 120
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# PYLINT CONFIGURATION                                                        #
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+[tool.pylint.main]
+extension-pkg-whitelist = "cv2"
+ignore = ["tests", "docs", "anomalib/models/components/freia"]
+ignored-modules = "cv2"
+
+[tool.pylint.messages_control]
+disable = [
+    "duplicate-code",
+    "arguments-differ",
+    "fixme",
+    "import-error",
+    "too-many-arguments",
+    "too-many-branches",
+    "too-many-instance-attributes",
+    "too-many-locals",
+    "too-few-public-methods",
 ]
+
+[tool.pylint.typecheck]
+generated-members = ["numpy.*", "torch.*"]
+
+[tool.pylint.basic]
+good-names = ["e", "i", "id"]
+
+[tool.pylint.format]
+max-line-length = 120
+
+[tool.pylint.design]
+max-parents = 15
+
+[tool.pylint.similarities]
+min-similarity-lines = 5
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# MYPY CONFIGURATION
+[tool.mypy]
+ignore_missing_imports = true
+show_error_codes = true
+exclude = ["anomalib/models/components/freia/"]
+
+# mypy per-module options:
+[[tool.mypy.overrides]]
+module = "anomalib.models.components.freia.*"
+follow_imports = "skip"
+
+[[tool.mypy.overrides]]
+module = "torch.*"
+follow_imports = "skip"
+follow_imports_for_stubs = true
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# COVERAGE CONFIGURATION                                                      #
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+[tool.coverage.report]
+exclude_lines = [
+    "except ImportError",
+    "raise ImportError",
+    "except ApiException",
+    "raise ApiException",
+    "raise ValueError",
+]
+
+[tool.pydocstyle]
+inherit = false
+ignore = [
+    "D107", # Missing docstring in __init__
+    "D202", # No blank lines allowed after function docstring
+    "D203", # 1 blank line required before class docstring
+    "D213", # Multi-line docstring summary should start at the second line
+    "D401", # First line should be in imperative mood; try rephrasing
+    "D404", # First word of the docstring should not be This
+    "D406", # Section name should end with a newline
+    "D407", # Missing dashed underline after section
+    "D413", # Missing blank line after last section
+]
+
+#
+# NBQA CONFIGURATION
+[tool.nbqa.addopts]
+pylint = ["--disable=C0103,C0114,C0116,E0401,R0801,W0106"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,20 @@
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# SETUP CONFIGURATION.                                                        #
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 [build-system]
 requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"
 
-#
-# ISORT Configuration.
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# ISORT CONFIGURATION.
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 [tool.isort]
 profile = "black"
 known_first_party = "wandb"
 sections = ['FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER']
 
-#
+
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # BLACK CONFIGURATION
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -19,6 +24,7 @@ line-length = 120
 [tool.flake8]
 ignore = ["E203", "W503"]
 max-line-length = 120
+
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # PYLINT CONFIGURATION                                                        #
@@ -58,7 +64,8 @@ min-similarity-lines = 5
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# MYPY CONFIGURATION
+# MYPY CONFIGURATION.                                                         #
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 [tool.mypy]
 ignore_missing_imports = true
 show_error_codes = true
@@ -101,7 +108,9 @@ ignore = [
     "D413", # Missing blank line after last section
 ]
 
-#
-# NBQA CONFIGURATION
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# NBQA CONFIGURATION                                                          #
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 [tool.nbqa.addopts]
 pylint = ["--disable=C0103,C0114,C0116,E0401,R0801,W0106"]

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ passenv = ftp_proxy
     CUDA_VISIBLE_DEVICES
     ANOMALIB_DATASET_PATH
 deps =
-    coverage
+    coverage[toml]
     pytest
     flaky
     -r{toxinidir}/requirements/base.txt
@@ -50,60 +50,3 @@ commands =
     ; https://github.com/openvinotoolkit/anomalib/issues/94
     coverage report -m --fail-under=33
     coverage xml -o {toxworkdir}/coverage.xml
-
-[flake8]
-max-line-length = 120
-ignore = E203,W503
-
-[pylint]
-extension-pkg-whitelist = cv2
-ignored-modules = cv2
-disable = duplicate-code,
-          arguments-differ,
-          fixme,
-          import-error,
-          too-many-arguments,
-          too-many-branches,
-          too-many-instance-attributes,
-          too-many-locals,
-          too-few-public-methods,
-
-generated-members = numpy.*, torch.*
-good-names = e, i, id
-ignore = tests,docs,anomalib/models/components/freia
-
-max-line-length = 120
-max-parents = 15
-min-similarity-lines = 5
-
-
-[mypy]
-ignore_missing_imports = True
-show_error_codes = True
-exclude = anomalib/models/components/freia/
-[mypy-anomalib.models.components.freia.*]
-follow_imports = skip
-[mypy-torch.*]
-follow_imports = skip
-follow_imports_for_stubs = True
-
-
-[coverage:report]
-exclude_lines =
-    except ImportError
-    raise ImportError
-    except ApiException
-    raise ApiException
-    raise ValueError
-
-[pydocstyle]
-inherit = false
-ignore = D107, ; Missing docstring in __init__
-         D202, ; No blank lines allowed after function docstring
-         D203, ; 1 blank line required before class docstring
-         D213, ; Multi-line docstring summary should start at the second line
-         D401, ; First line should be in imperative mood; try rephrasing
-         D404, ; First word of the docstring should not be This
-         D406, ; Section name should end with a newline
-         D407, ; Missing dashed underline after section
-         D413 ; Missing blank line after last section


### PR DESCRIPTION
# Description

- Currently linter configuration are stored in `tox.ini`. This PR moves these configurations to `pyproject.toml` to separate the responsibilities of these two files. `tox.ini` will now handle the test automation, while `pyproject.toml` will sort out setup and configuration.

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
