### PR TITLE
fix inference for draem

### DIFF
--- a/anomalib/deploy/inferencers/openvino_inferencer.py
+++ b/anomalib/deploy/inferencers/openvino_inferencer.py
@@ -104,9 +104,11 @@ class OpenVINOInferencer(Inferencer):
         Returns:
             np.ndarray: pre-processed image.
         """
-        config = self.config.transform if "transform" in self.config.keys() else None
+        transform_config = (
+            self.config.dataset.transform_config.val if "transform_config" in self.config.dataset.keys() else None
+        )
         image_size = tuple(self.config.dataset.image_size)
-        pre_processor = PreProcessor(config, image_size)
+        pre_processor = PreProcessor(transform_config, image_size)
         processed_image = pre_processor(image=image)["image"]
 
         if len(processed_image.shape) == 3:

--- a/anomalib/deploy/inferencers/torch_inferencer.py
+++ b/anomalib/deploy/inferencers/torch_inferencer.py
@@ -106,9 +106,11 @@ class TorchInferencer(Inferencer):
         Returns:
             Tensor: pre-processed image.
         """
-        config = self.config.transform if "transform" in self.config.keys() else None
+        transform_config = (
+            self.config.dataset.transform_config.val if "transform_config" in self.config.dataset.keys() else None
+        )
         image_size = tuple(self.config.dataset.image_size)
-        pre_processor = PreProcessor(config, image_size)
+        pre_processor = PreProcessor(transform_config, image_size)
         processed_image = pre_processor(image=image)["image"]
 
         if len(processed_image) == 3:
@@ -143,7 +145,7 @@ class TorchInferencer(Inferencer):
             meta_data = self.meta_data
 
         if isinstance(predictions, Tensor):
-            anomaly_map = predictions.cpu().numpy()
+            anomaly_map = predictions.detach().cpu().numpy()
             pred_score = anomaly_map.reshape(-1).max()
         else:
             # NOTE: Patchcore `forward`` returns heatmap and score.

--- a/anomalib/models/draem/lightning_model.py
+++ b/anomalib/models/draem/lightning_model.py
@@ -68,7 +68,7 @@ class Draem(AnomalyModule):
             Dictionary to which predicted anomaly maps have been added.
         """
         prediction = self.model(batch["image"])
-        batch["anomaly_maps"] = prediction[:, 1, :, :]
+        batch["anomaly_maps"] = prediction
         return batch
 
 

--- a/anomalib/models/draem/torch_model.py
+++ b/anomalib/models/draem/torch_model.py
@@ -38,7 +38,7 @@ class DraemModel(nn.Module):
         prediction = self.discriminative_subnetwork(concatenated_inputs)
         if self.training:
             return reconstruction, prediction
-        return torch.softmax(prediction, dim=1)
+        return torch.softmax(prediction, dim=1)[:, 1, ...]
 
 
 class ReconstructiveSubNetwork(nn.Module):

--- a/tools/inference/lightning_inference.py
+++ b/tools/inference/lightning_inference.py
@@ -63,7 +63,10 @@ def infer():
 
     trainer = Trainer(callbacks=callbacks, **config.trainer)
 
-    dataset = InferenceDataset(args.input, image_size=tuple(config.dataset.image_size))
+    transform_config = config.dataset.transform_config.val if "transform_config" in config.dataset.keys() else None
+    dataset = InferenceDataset(
+        args.input, image_size=tuple(config.dataset.image_size), transform_config=transform_config
+    )
     dataloader = DataLoader(dataset)
     trainer.predict(model=model, dataloaders=[dataloader])
 


### PR DESCRIPTION
# Description
This PR fixes inference for DRAEM and possibly other models.

- The transform config files were not loaded correctly in each of the three inferencers, so the default transform config was always used. This is solved now by retrieving the transform config from the config file using the correct key.
- The torch model from the DRAEM implementation now returns an anomaly map when in inference mode, instead of the confidence scores for both classes. This makes the model compatible with the torch and openvino inferencers.

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
