### PR TITLE
DFKDE refactor to accept any layer name like other models

### DIFF
--- a/anomalib/models/dfkde/config.yaml
+++ b/anomalib/models/dfkde/config.yaml
@@ -24,6 +24,8 @@ model:
   threshold_steepness: 0.05
   threshold_offset: 12
   normalization_method: min_max # options: [null, min_max, cdf]
+  layers:
+    - avgpool
 
 metrics:
   image:

--- a/anomalib/models/dfkde/lightning_model.py
+++ b/anomalib/models/dfkde/lightning_model.py
@@ -47,6 +47,7 @@ class Dfkde(AnomalyModule):
 
     def __init__(
         self,
+        layers: List[str],
         backbone: str,
         pre_trained: bool = True,
         max_training_points: int = 40000,
@@ -58,6 +59,7 @@ class Dfkde(AnomalyModule):
         super().__init__()
 
         self.model = DfkdeModel(
+            layers=layers,
             backbone=backbone,
             pre_trained=pre_trained,
             n_comps=n_components,
@@ -126,6 +128,7 @@ class DfkdeLightning(Dfkde):
 
     def __init__(self, hparams: Union[DictConfig, ListConfig]) -> None:
         super().__init__(
+            layers=hparams.model.layers,
             backbone=hparams.model.backbone,
             max_training_points=hparams.model.max_training_points,
             pre_processing=hparams.model.pre_processing,

--- a/anomalib/models/dfkde/torch_model.py
+++ b/anomalib/models/dfkde/torch_model.py
@@ -43,6 +43,7 @@ class DfkdeModel(nn.Module):
 
     def __init__(
         self,
+        layers: List[str],
         backbone: str,
         pre_trained: bool = True,
         n_comps: int = 16,
@@ -59,7 +60,8 @@ class DfkdeModel(nn.Module):
         self.threshold_offset = threshold_offset
 
         _backbone = getattr(torchvision.models, backbone)
-        self.feature_extractor = FeatureExtractor(backbone=_backbone(pretrained=pre_trained), layers=["avgpool"]).eval()
+        self.layers = layers
+        self.feature_extractor = FeatureExtractor(backbone=_backbone(pretrained=pre_trained), layers=layers).eval()
 
         self.pca_model = PCA(n_components=self.n_components)
         self.kde_model = GaussianKDE()

--- a/anomalib/models/dfkde/torch_model.py
+++ b/anomalib/models/dfkde/torch_model.py
@@ -60,7 +60,6 @@ class DfkdeModel(nn.Module):
         self.threshold_offset = threshold_offset
 
         _backbone = getattr(torchvision.models, backbone)
-        self.layers = layers
         self.feature_extractor = FeatureExtractor(backbone=_backbone(pretrained=pre_trained), layers=layers).eval()
 
         self.pca_model = PCA(n_components=self.n_components)

--- a/configs/model/dfkde.yaml
+++ b/configs/model/dfkde.yaml
@@ -24,6 +24,8 @@ model:
   init_args:
     backbone: resnet18
     pre_trained: true
+    layers:
+      - avgpool
     max_training_points: 40000
     pre_processing: scale
     n_components: 16


### PR DESCRIPTION
# Description

Slight refactor of the DFKDE model to accept from the config file the name of the layer needed. Currently this is hard coded to `avgpool` but to be consistent with other models will need to make this configurable.

## Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [X] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing tests pass locally with my changes
