### PR TITLE
Add reset methods to metrics

### DIFF
--- a/anomalib/utils/metrics/adaptive_threshold.py
+++ b/anomalib/utils/metrics/adaptive_threshold.py
@@ -44,3 +44,7 @@ class AdaptiveThreshold(Metric):
         else:
             self.value = thresholds[torch.argmax(f1_score)]
         return self.value
+
+    def reset(self) -> None:
+        """Reset the metric."""
+        self.precision_recall_curve.reset()

--- a/anomalib/utils/metrics/optimal_f1.py
+++ b/anomalib/utils/metrics/optimal_f1.py
@@ -40,3 +40,7 @@ class OptimalF1(Metric):
         self.threshold = thresholds[torch.argmax(f1_score)]
         optimal_f1_score = torch.max(f1_score)
         return optimal_f1_score
+
+    def reset(self) -> None:
+        """Reset the metric."""
+        self.precision_recall_curve.reset()


### PR DESCRIPTION
# Description

- Adds `reset` method to metrics as suggested in issue #457 

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update