### PR TITLE
fix Perlin augmenter for non divisible image sizes

### DIFF
--- a/anomalib/models/draem/utils/augmenter.py
+++ b/anomalib/models/draem/utils/augmenter.py
@@ -11,6 +11,7 @@
 
 
 import glob
+import math
 import random
 from typing import Optional, Tuple
 
@@ -22,6 +23,11 @@ from torch import Tensor
 from torchvision.datasets.folder import IMG_EXTENSIONS
 
 from anomalib.data.utils import random_2d_perlin
+
+
+def nextpow2(value):
+    """Returns the smallest power of 2 greater than or equal to the input value."""
+    return 2 ** (math.ceil(math.log(value, 2)))
 
 
 class Augmenter:
@@ -84,7 +90,9 @@ class Augmenter:
         perlin_scalex = 2 ** random.randint(min_perlin_scale, perlin_scale)
         perlin_scaley = 2 ** random.randint(min_perlin_scale, perlin_scale)
 
-        perlin_noise = random_2d_perlin((height, width), (perlin_scalex, perlin_scaley))
+        perlin_noise = random_2d_perlin((nextpow2(height), nextpow2(width)), (perlin_scalex, perlin_scaley))[
+            :height, :width
+        ]
         perlin_noise = self.rot(image=perlin_noise)
 
         # Create mask from perlin noise


### PR DESCRIPTION
# Description

- Perlin noise augmentation for DRAEM was instable for image sizes that were not a power of 2. This PR adds a quick fix for this issue by generating the Perlin noise mask with a dimensionality equal to the nearest power of 2 and then cropping back to the original image size.
- This temporarily fixes the issues with DRAEM until we create our own implementation of Perlin noise.

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
