### PR TITLE
FIX: PaDiM didn't use config.model.pre_trained.

### DIFF
--- a/anomalib/models/padim/lightning_model.py
+++ b/anomalib/models/padim/lightning_model.py
@@ -118,6 +118,7 @@ class PadimLightning(Padim):
             input_size=hparams.model.input_size,
             layers=hparams.model.layers,
             backbone=hparams.model.backbone,
+            pre_trained=hparams.model.pre_trained,
         )
         self.hparams: Union[DictConfig, ListConfig]  # type: ignore
         self.save_hyperparameters(hparams)


### PR DESCRIPTION
# Description

PaDim did not use 'pre_trained' value in config.yaml. This PR fixes it.

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
