### PR TITLE
Ignore pixel metrics in classification task

### DIFF
--- a/anomalib/utils/callbacks/__init__.py
+++ b/anomalib/utils/callbacks/__init__.py
@@ -74,8 +74,8 @@ def get_callbacks(config: Union[ListConfig, DictConfig]) -> List[Callback]:
         config.metrics.threshold.pixel_default if "pixel_default" in config.metrics.threshold.keys() else None
     )
     metrics_callback = MetricsConfigurationCallback(
-        config.dataset.task,
         config.metrics.threshold.adaptive,
+        config.dataset.task,
         image_threshold,
         pixel_threshold,
         image_metric_names,

--- a/anomalib/utils/callbacks/__init__.py
+++ b/anomalib/utils/callbacks/__init__.py
@@ -74,6 +74,7 @@ def get_callbacks(config: Union[ListConfig, DictConfig]) -> List[Callback]:
         config.metrics.threshold.pixel_default if "pixel_default" in config.metrics.threshold.keys() else None
     )
     metrics_callback = MetricsConfigurationCallback(
+        config.dataset.task,
         config.metrics.threshold.adaptive,
         image_threshold,
         pixel_threshold,

--- a/anomalib/utils/callbacks/metrics_configuration.py
+++ b/anomalib/utils/callbacks/metrics_configuration.py
@@ -26,8 +26,8 @@ class MetricsConfigurationCallback(Callback):
 
     def __init__(
         self,
-        task: str,
         adaptive_threshold: bool,
+        task: str = "segmentation",
         default_image_threshold: Optional[float] = None,
         default_pixel_threshold: Optional[float] = None,
         image_metric_names: Optional[List[str]] = None,

--- a/anomalib/utils/cli/cli.py
+++ b/anomalib/utils/cli/cli.py
@@ -111,6 +111,7 @@ class AnomalibCLI(LightningCLI):
         parser.set_defaults(
             {
                 "metrics.adaptive_threshold": True,
+                "metrics.task": "segmentation",
                 "metrics.default_image_threshold": None,
                 "metrics.default_pixel_threshold": None,
                 "metrics.image_metric_names": ["F1Score", "AUROC"],


### PR DESCRIPTION
# Description

- This PR makes sure that validation/testing does not fail when pixel metrics are requested in a classification task. Instead, the metrics configuration callback will ignore the pixel metrics and show a warning to the user.

- Fixes https://github.com/openvinotoolkit/anomalib/issues/513

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
