### PR TITLE
🔨 Pass `pre-trained` from config to `ModelLightning`

### DIFF
--- a/anomalib/models/cflow/lightning_model.py
+++ b/anomalib/models/cflow/lightning_model.py
@@ -185,6 +185,7 @@ class CflowLightning(Cflow):
             input_size=hparams.model.input_size,
             backbone=hparams.model.backbone,
             layers=hparams.model.layers,
+            pre_trained=hparams.model.pre_trained,
             fiber_batch_size=hparams.dataset.fiber_batch_size,
             decoder=hparams.model.decoder,
             condition_vector=hparams.model.condition_vector,

--- a/anomalib/models/dfkde/lightning_model.py
+++ b/anomalib/models/dfkde/lightning_model.py
@@ -119,6 +119,7 @@ class DfkdeLightning(Dfkde):
         super().__init__(
             layers=hparams.model.layers,
             backbone=hparams.model.backbone,
+            pre_trained=hparams.model.pre_trained,
             max_training_points=hparams.model.max_training_points,
             pre_processing=hparams.model.pre_processing,
             n_components=hparams.model.n_components,

--- a/anomalib/models/dfm/lightning_model.py
+++ b/anomalib/models/dfm/lightning_model.py
@@ -118,6 +118,7 @@ class DfmLightning(Dfm):
         super().__init__(
             backbone=hparams.model.backbone,
             layer=hparams.model.layer,
+            pre_trained=hparams.model.pre_trained,
             pooling_kernel_size=hparams.model.pooling_kernel_size,
             pca_level=hparams.model.pca_level,
             score_type=hparams.model.score_type,

--- a/anomalib/models/fastflow/lightning_model.py
+++ b/anomalib/models/fastflow/lightning_model.py
@@ -90,6 +90,7 @@ class FastflowLightning(Fastflow):
         super().__init__(
             input_size=hparams.model.input_size,
             backbone=hparams.model.backbone,
+            pre_trained=hparams.model.pre_trained,
             flow_steps=hparams.model.flow_steps,
             conv3x3_only=hparams.model.conv3x3_only,
             hidden_ratio=hparams.model.hidden_ratio,

--- a/anomalib/models/patchcore/lightning_model.py
+++ b/anomalib/models/patchcore/lightning_model.py
@@ -124,6 +124,7 @@ class PatchcoreLightning(Patchcore):
             input_size=hparams.model.input_size,
             backbone=hparams.model.backbone,
             layers=hparams.model.layers,
+            pre_trained=hparams.model.pre_trained,
             coreset_sampling_ratio=hparams.model.coreset_sampling_ratio,
             num_neighbors=hparams.model.num_neighbors,
         )

--- a/anomalib/models/reverse_distillation/lightning_model.py
+++ b/anomalib/models/reverse_distillation/lightning_model.py
@@ -121,6 +121,7 @@ class ReverseDistillationLightning(ReverseDistillation):
             input_size=hparams.model.input_size,
             backbone=hparams.model.backbone,
             layers=hparams.model.layers,
+            pre_trained=hparams.model.pre_trained,
             anomaly_map_mode=hparams.model.anomaly_map_mode,
             lr=hparams.model.lr,
             beta1=hparams.model.beta1,


### PR DESCRIPTION
# Description

- Following #514, this PR adds `pre_trained` parameter to `ModelLightning` implementation.

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
