### PR TITLE
🐞 Bug Fix: Solve NaN values of anomaly scores for PatchCore model

### DIFF
--- a/anomalib/models/patchcore/anomaly_map.py
+++ b/anomalib/models/patchcore/anomaly_map.py
@@ -57,7 +57,7 @@ class AnomalyMapGenerator(nn.Module):
         """
         max_scores = torch.argmax(patch_scores[:, 0])
         confidence = torch.index_select(patch_scores, 0, max_scores)
-        weights = 1 - (torch.max(torch.exp(confidence)) / torch.sum(torch.exp(confidence)))
+        weights = 1 - torch.max(F.softmax(confidence, dim=-1))
         score = weights * torch.max(patch_scores[:, 0])
         return score
 


### PR DESCRIPTION
# Description

For images with large defects, the anomaly score of the patchcore method is  sometimes nan in the actual version. This is due to the formula used to compute it,  that involves torch.exp. To remedy this, one can replace the actual computation with a softmax that is more stable numerically and is able to deal with large values. This replacement is only correct and equivalent to the previous formula because the confidence tensor is of shape (1,N), N being the nearest neighbors.


- Fixes #324 

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
