### PR TITLE
Refactor data modules

### DIFF
--- a/anomalib/data/__init__.py
+++ b/anomalib/data/__init__.py
@@ -7,7 +7,8 @@ import logging
 from typing import Union
 
 from omegaconf import DictConfig, ListConfig
-from pytorch_lightning import LightningDataModule
+
+from anomalib.data.base import AnomalibDataModule
 
 from .btech import BTech
 from .folder import Folder
@@ -17,7 +18,7 @@ from .mvtec import MVTec
 logger = logging.getLogger(__name__)
 
 
-def get_datamodule(config: Union[DictConfig, ListConfig]) -> LightningDataModule:
+def get_datamodule(config: Union[DictConfig, ListConfig]) -> AnomalibDataModule:
     """Get Anomaly Datamodule.
 
     Args:
@@ -28,7 +29,7 @@ def get_datamodule(config: Union[DictConfig, ListConfig]) -> LightningDataModule
     """
     logger.info("Loading the datamodule")
 
-    datamodule: LightningDataModule
+    datamodule: AnomalibDataModule
 
     if config.dataset.format.lower() == "mvtec":
         datamodule = MVTec(

--- a/anomalib/data/base.py
+++ b/anomalib/data/base.py
@@ -33,7 +33,7 @@ class AnomalibDataset(Dataset):
 
     def contains_anomalous_images(self):
         """Check if the dataset contains any anomalous images."""
-        return "anomalous" in list(self.samples.label)
+        return 1 in list(self.samples.label_index)
 
     def __len__(self) -> int:
         """Get length of the dataset."""

--- a/anomalib/data/base.py
+++ b/anomalib/data/base.py
@@ -124,6 +124,7 @@ class AnomalibDataModule(LightningDataModule, ABC):
         | 0 | path/to/image.png | anomalous | 0           | path/to/mask.png | train |
         |---|-------------------|-----------|-------------|------------------|-------|
         """
+        raise NotImplementedError
 
     def setup(self, stage: Optional[str] = None) -> None:
         """Setup train, validation and test data.

--- a/anomalib/data/base.py
+++ b/anomalib/data/base.py
@@ -49,16 +49,16 @@ class AnomalibDataset(Dataset):
             Union[Dict[str, Tensor], Dict[str, Union[str, Tensor]]]: Dict of image tensor during training.
                 Otherwise, Dict containing image path, target path, image tensor, label and transformed bounding box.
         """
-        image_path = self.samples.image_path[index]
+        image_path = self.samples.iloc[index].image_path
         image = read_image(image_path)
-        label_index = self.samples.label_index[index]
+        label_index = self.samples.iloc[index].label_index
 
         item = dict(image_path=image_path, label=label_index)
 
         if self.task == "classification":
             pre_processed = self.pre_process(image=image)
         elif self.task == "segmentation":
-            mask_path = self.samples.mask_path[index]
+            mask_path = self.samples.iloc[index].mask_path
 
             # Only Anomalous (1) images have masks in anomaly datasets
             # Therefore, create empty mask for Normal (0) images.

--- a/anomalib/data/base.py
+++ b/anomalib/data/base.py
@@ -1,0 +1,33 @@
+"""Anomalib dataset and datamodule base classes."""
+
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from abc import ABC
+from typing import Optional
+
+from pandas import DataFrame
+from pytorch_lightning import LightningDataModule
+from torch.utils.data import Dataset
+
+
+class AnomalibDataset(Dataset, ABC):
+    """Base Anomalib dataset."""
+
+    def __init__(self, samples: DataFrame):
+        super().__init__()
+        self.samples = samples
+
+    def contains_anomalous_images(self):
+        """Check if the dataset contains any anomalous images."""
+        return "anomalous" in list(self.samples.label)
+
+
+class AnomalibDataModule(LightningDataModule):
+    """Base Anomalib data module."""
+
+    def __init__(self):
+        super().__init__()
+        self.train_data: Optional[AnomalibDataset] = None
+        self.val_data: Optional[AnomalibDataset] = None
+        self.test_data: Optional[AnomalibDataset] = None

--- a/anomalib/data/base.py
+++ b/anomalib/data/base.py
@@ -64,7 +64,7 @@ class AnomalibDataset(Dataset):
             if self.task == "segmentation":
                 mask_path = self.samples.mask_path[index]
 
-                # Only Anomalous (1) images has masks in MVTec AD dataset.
+                # Only Anomalous (1) images have masks in anomaly datasets
                 # Therefore, create empty mask for Normal (0) images.
                 if label_index == 0:
                     mask = np.zeros(shape=image.shape[:2])

--- a/anomalib/data/base.py
+++ b/anomalib/data/base.py
@@ -4,26 +4,79 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABC
-from typing import Optional
+from typing import Dict, Optional, Union
 
+import cv2
+import numpy as np
 from pandas import DataFrame
 from pytorch_lightning import LightningDataModule
+from torch import Tensor
 from torch.utils.data import Dataset
 
+from anomalib.data.utils import read_image
+from anomalib.pre_processing import PreProcessor
 
-class AnomalibDataset(Dataset, ABC):
-    """Base Anomalib dataset."""
 
-    def __init__(self, samples: DataFrame):
+class AnomalibDataset(Dataset):
+    """Anomalib dataset."""
+
+    def __init__(self, samples: DataFrame, task: str, split: str, pre_process: PreProcessor):
         super().__init__()
         self.samples = samples
+        self.task = task
+        self.split = split
+        self.pre_process = pre_process
 
     def contains_anomalous_images(self):
         """Check if the dataset contains any anomalous images."""
         return "anomalous" in list(self.samples.label)
 
+    def __len__(self) -> int:
+        """Get length of the dataset."""
+        return len(self.samples)
 
-class AnomalibDataModule(LightningDataModule):
+    def __getitem__(self, index: int) -> Dict[str, Union[str, Tensor]]:
+        """Get dataset item for the index ``index``.
+
+        Args:
+            index (int): Index to get the item.
+
+        Returns:
+            Union[Dict[str, Tensor], Dict[str, Union[str, Tensor]]]: Dict of image tensor during training.
+                Otherwise, Dict containing image path, target path, image tensor, label and transformed bounding box.
+        """
+        image_path = self.samples.image_path[index]
+        image = read_image(image_path)
+
+        pre_processed = self.pre_process(image=image)
+        item = {"image": pre_processed["image"]}
+
+        if self.split in ["val", "test"]:
+            label_index = self.samples.label_index[index]
+
+            item["image_path"] = image_path
+            item["label"] = label_index
+
+            if self.task == "segmentation":
+                mask_path = self.samples.mask_path[index]
+
+                # Only Anomalous (1) images has masks in MVTec AD dataset.
+                # Therefore, create empty mask for Normal (0) images.
+                if label_index == 0:
+                    mask = np.zeros(shape=image.shape[:2])
+                else:
+                    mask = cv2.imread(mask_path, flags=0) / 255.0
+
+                pre_processed = self.pre_process(image=image, mask=mask)
+
+                item["mask_path"] = mask_path
+                item["image"] = pre_processed["image"]
+                item["mask"] = pre_processed["mask"]
+
+        return item
+
+
+class AnomalibDataModule(LightningDataModule, ABC):
     """Base Anomalib data module."""
 
     def __init__(self):

--- a/anomalib/data/base.py
+++ b/anomalib/data/base.py
@@ -106,7 +106,24 @@ class AnomalibDataModule(LightningDataModule, ABC):
 
     @abstractmethod
     def _create_samples(self) -> DataFrame:
-        """To be implemented in subclass."""
+        """This method should be implemented in the subclass.
+
+        This method should return a dataframe that contains the information needed by the dataloader to load each of
+        the dataset items into memory. The dataframe must at least contain the following columns:
+        split - The subset to which the dataset item is assigned.
+        image_path - Path to file system location where the image is stored.
+        label_index - Index of the anomaly label, typically 0 for "normal" and 1 for "anomalous".
+
+        Additionally, when the task type is segmentation, the dataframe must have the mask_path column, which contains
+        the path the ground truth masks (for the anomalous images only).
+
+        Example of a dataframe returned by calling this method from a concrete class:
+        |---|-------------------|-----------|-------------|------------------|-------|
+        |   | image_path        | label     | label_index | mask_path        | split |
+        |---|-------------------|-----------|-------------|------------------|-------|
+        | 0 | path/to/image.png | anomalous | 0           | path/to/mask.png | train |
+        |---|-------------------|-----------|-------------|------------------|-------|
+        """
 
     def setup(self, stage: Optional[str] = None) -> None:
         """Setup train, validation and test data.

--- a/anomalib/data/btech.py
+++ b/anomalib/data/btech.py
@@ -194,7 +194,7 @@ class BTech(AnomalibDataModule):
             + "/ground_truth/"
             + samples.label
             + "/"
-            + samples.image_path.str.rstrip("bmp").str.rstrip(".")
+            + samples.image_path.str.rstrip("bmp|png").str.rstrip(".")
             + ".png"
         )
 

--- a/anomalib/data/btech.py
+++ b/anomalib/data/btech.py
@@ -93,6 +93,14 @@ class BTech(AnomalibDataModule):
             >>> data["image"].shape, data["mask"].shape
             (torch.Size([32, 3, 256, 256]), torch.Size([32, 256, 256]))
         """
+        self.root = root if isinstance(root, Path) else Path(root)
+        self.category = category
+        self.path = self.root / self.category
+
+        self.create_validation_set = create_validation_set
+        self.seed = seed
+        self.split_ratio = split_ratio
+
         super().__init__(
             task=task,
             train_batch_size=train_batch_size,
@@ -103,14 +111,6 @@ class BTech(AnomalibDataModule):
             image_size=image_size,
             create_validation_set=create_validation_set,
         )
-
-        self.root = root if isinstance(root, Path) else Path(root)
-        self.category = category
-        self.path = self.root / self.category
-
-        self.create_validation_set = create_validation_set
-        self.seed = seed
-        self.split_ratio = split_ratio
 
     def prepare_data(self) -> None:
         """Download the dataset if not available."""

--- a/anomalib/data/btech.py
+++ b/anomalib/data/btech.py
@@ -21,8 +21,6 @@ import cv2
 import pandas as pd
 from pandas.core.frame import DataFrame
 from pytorch_lightning.utilities.cli import DATAMODULE_REGISTRY
-from pytorch_lightning.utilities.types import EVAL_DATALOADERS, TRAIN_DATALOADERS
-from torch.utils.data import DataLoader
 from tqdm import tqdm
 
 from anomalib.data.base import AnomalibDataModule
@@ -97,6 +95,9 @@ class BTech(AnomalibDataModule):
         """
         super().__init__(
             task=task,
+            train_batch_size=train_batch_size,
+            test_batch_size=test_batch_size,
+            num_workers=num_workers,
             transform_config_train=transform_config_train,
             transform_config_val=transform_config_val,
             image_size=image_size,
@@ -106,16 +107,8 @@ class BTech(AnomalibDataModule):
         self.root = root if isinstance(root, Path) else Path(root)
         self.category = category
         self.path = self.root / self.category
-        self.transform_config_train = transform_config_train
-        self.transform_config_val = transform_config_val
-        self.image_size = image_size
-
-        self.train_batch_size = train_batch_size
-        self.test_batch_size = test_batch_size
-        self.num_workers = num_workers
 
         self.create_validation_set = create_validation_set
-        self.task = task
         self.seed = seed
         self.split_ratio = split_ratio
 
@@ -219,16 +212,3 @@ class BTech(AnomalibDataModule):
             samples = create_validation_set_from_test_set(samples, seed=self.seed)
 
         return samples
-
-    def train_dataloader(self) -> TRAIN_DATALOADERS:
-        """Get train dataloader."""
-        return DataLoader(self.train_data, shuffle=True, batch_size=self.train_batch_size, num_workers=self.num_workers)
-
-    def val_dataloader(self) -> EVAL_DATALOADERS:
-        """Get validation dataloader."""
-        dataset = self.val_data if self.create_validation_set else self.test_data
-        return DataLoader(dataset=dataset, shuffle=False, batch_size=self.test_batch_size, num_workers=self.num_workers)
-
-    def test_dataloader(self) -> EVAL_DATALOADERS:
-        """Get test dataloader."""
-        return DataLoader(self.test_data, shuffle=False, batch_size=self.test_batch_size, num_workers=self.num_workers)

--- a/anomalib/data/btech.py
+++ b/anomalib/data/btech.py
@@ -11,260 +11,38 @@ extracts the dataset and create PyTorch data objects.
 
 import logging
 import shutil
-import warnings
 import zipfile
 from pathlib import Path
-from typing import Dict, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
 from urllib.request import urlretrieve
 
 import albumentations as A
 import cv2
-import numpy as np
 import pandas as pd
 from pandas.core.frame import DataFrame
-from pytorch_lightning.core.datamodule import LightningDataModule
 from pytorch_lightning.utilities.cli import DATAMODULE_REGISTRY
 from pytorch_lightning.utilities.types import EVAL_DATALOADERS, TRAIN_DATALOADERS
-from torch import Tensor
 from torch.utils.data import DataLoader
-from torch.utils.data.dataset import Dataset
-from torchvision.datasets.folder import VisionDataset
 from tqdm import tqdm
 
-from anomalib.data.inference import InferenceDataset
-from anomalib.data.utils import DownloadProgressBar, hash_check, read_image
+from anomalib.data.base import AnomalibDataModule
+from anomalib.data.utils import DownloadProgressBar, hash_check
 from anomalib.data.utils.split import (
     create_validation_set_from_test_set,
     split_normal_images_in_train_set,
 )
-from anomalib.pre_processing import PreProcessor
 
 logger = logging.getLogger(__name__)
 
 
-def make_btech_dataset(
-    path: Path,
-    split: Optional[str] = None,
-    split_ratio: float = 0.1,
-    seed: Optional[int] = None,
-    create_validation_set: bool = False,
-) -> DataFrame:
-    """Create BTech samples by parsing the BTech data file structure.
-
-    The files are expected to follow the structure:
-        path/to/dataset/split/category/image_filename.png
-        path/to/dataset/ground_truth/category/mask_filename.png
-
-    Args:
-        path (Path): Path to dataset
-        split (str, optional): Dataset split (ie., either train or test). Defaults to None.
-        split_ratio (float, optional): Ratio to split normal training images and add to the
-            test set in case test set doesn't contain any normal images.
-            Defaults to 0.1.
-        seed (int, optional): Random seed to ensure reproducibility when splitting. Defaults to 0.
-        create_validation_set (bool, optional): Boolean to create a validation set from the test set.
-            BTech dataset does not contain a validation set. Those wanting to create a validation set
-            could set this flag to ``True``.
-
-    Example:
-        The following example shows how to get training samples from BTech 01 category:
-
-        >>> root = Path('./BTech')
-        >>> category = '01'
-        >>> path = root / category
-        >>> path
-        PosixPath('BTech/01')
-
-        >>> samples = make_btech_dataset(path, split='train', split_ratio=0.1, seed=0)
-        >>> samples.head()
-           path     split label image_path                  mask_path                     label_index
-        0  BTech/01 train 01    BTech/01/train/ok/105.bmp BTech/01/ground_truth/ok/105.png      0
-        1  BTech/01 train 01    BTech/01/train/ok/017.bmp BTech/01/ground_truth/ok/017.png      0
-        ...
-
-    Returns:
-        DataFrame: an output dataframe containing samples for the requested split (ie., train or test)
-    """
-    samples_list = [
-        (str(path),) + filename.parts[-3:] for filename in path.glob("**/*") if filename.suffix in (".bmp", ".png")
-    ]
-    if len(samples_list) == 0:
-        raise RuntimeError(f"Found 0 images in {path}")
-
-    samples = pd.DataFrame(samples_list, columns=["path", "split", "label", "image_path"])
-    samples = samples[samples.split != "ground_truth"]
-
-    # Create mask_path column
-    samples["mask_path"] = (
-        samples.path
-        + "/ground_truth/"
-        + samples.label
-        + "/"
-        + samples.image_path.str.rstrip("png").str.rstrip(".")
-        + ".png"
-    )
-
-    # Modify image_path column by converting to absolute path
-    samples["image_path"] = samples.path + "/" + samples.split + "/" + samples.label + "/" + samples.image_path
-
-    # Split the normal images in training set if test set doesn't
-    # contain any normal images. This is needed because AUC score
-    # cannot be computed based on 1-class
-    if sum((samples.split == "test") & (samples.label == "ok")) == 0:
-        samples = split_normal_images_in_train_set(samples, split_ratio, seed)
-
-    # Good images don't have mask
-    samples.loc[(samples.split == "test") & (samples.label == "ok"), "mask_path"] = ""
-
-    # Create label index for normal (0) and anomalous (1) images.
-    samples.loc[(samples.label == "ok"), "label_index"] = 0
-    samples.loc[(samples.label != "ok"), "label_index"] = 1
-    samples.label_index = samples.label_index.astype(int)
-
-    if create_validation_set:
-        samples = create_validation_set_from_test_set(samples, seed=seed)
-
-    # Get the data frame for the split.
-    if split is not None and split in ["train", "val", "test"]:
-        samples = samples[samples.split == split]
-        samples = samples.reset_index(drop=True)
-
-    return samples
-
-
-class BTechDataset(VisionDataset):
-    """BTech PyTorch Dataset."""
-
-    def __init__(
-        self,
-        root: Union[Path, str],
-        category: str,
-        pre_process: PreProcessor,
-        split: str,
-        task: str = "segmentation",
-        seed: Optional[int] = None,
-        create_validation_set: bool = False,
-    ) -> None:
-        """Btech Dataset class.
-
-        Args:
-            root: Path to the BTech dataset
-            category: Name of the BTech category.
-            pre_process: List of pre_processing object containing albumentation compose.
-            split: 'train', 'val' or 'test'
-            task: ``classification`` or ``segmentation``
-            seed: seed used for the random subset splitting
-            create_validation_set: Create a validation subset in addition to the train and test subsets
-
-        Examples:
-            >>> from anomalib.data.btech import BTechDataset
-            >>> from anomalib.data.transforms import PreProcessor
-            >>> pre_process = PreProcessor(image_size=256)
-            >>> dataset = BTechDataset(
-            ...     root='./datasets/BTech',
-            ...     category='leather',
-            ...     pre_process=pre_process,
-            ...     task="classification",
-            ...     is_train=True,
-            ... )
-            >>> dataset[0].keys()
-            dict_keys(['image'])
-
-            >>> dataset.split = "test"
-            >>> dataset[0].keys()
-            dict_keys(['image', 'image_path', 'label'])
-
-            >>> dataset.task = "segmentation"
-            >>> dataset.split = "train"
-            >>> dataset[0].keys()
-            dict_keys(['image'])
-
-            >>> dataset.split = "test"
-            >>> dataset[0].keys()
-            dict_keys(['image_path', 'label', 'mask_path', 'image', 'mask'])
-
-            >>> dataset[0]["image"].shape, dataset[0]["mask"].shape
-            (torch.Size([3, 256, 256]), torch.Size([256, 256]))
-        """
-        super().__init__(root)
-
-        if seed is None:
-            warnings.warn(
-                "seed is None."
-                " When seed is not set, images from the normal directory are split between training and test dir."
-                " This will lead to inconsistency between runs."
-            )
-
-        self.root = Path(root) if isinstance(root, str) else root
-        self.category: str = category
-        self.split = split
-        self.task = task
-
-        self.pre_process = pre_process
-
-        self.samples = make_btech_dataset(
-            path=self.root / category,
-            split=self.split,
-            seed=seed,
-            create_validation_set=create_validation_set,
-        )
-
-    def __len__(self) -> int:
-        """Get length of the dataset."""
-        return len(self.samples)
-
-    def __getitem__(self, index: int) -> Dict[str, Union[str, Tensor]]:
-        """Get dataset item for the index ``index``.
-
-        Args:
-            index (int): Index to get the item.
-
-        Returns:
-            Union[Dict[str, Tensor], Dict[str, Union[str, Tensor]]]: Dict of image tensor during training.
-                Otherwise, Dict containing image path, target path, image tensor, label and transformed bounding box.
-        """
-        item: Dict[str, Union[str, Tensor]] = {}
-
-        image_path = self.samples.image_path[index]
-        image = read_image(image_path)
-
-        pre_processed = self.pre_process(image=image)
-        item = {"image": pre_processed["image"]}
-
-        if self.split in ["val", "test"]:
-            label_index = self.samples.label_index[index]
-
-            item["image_path"] = image_path
-            item["label"] = label_index
-
-            if self.task == "segmentation":
-                mask_path = self.samples.mask_path[index]
-
-                # Only Anomalous (1) images has masks in BTech dataset.
-                # Therefore, create empty mask for Normal (0) images.
-                if label_index == 0:
-                    mask = np.zeros(shape=image.shape[:2])
-                else:
-                    mask = cv2.imread(mask_path, flags=0) / 255.0
-
-                pre_processed = self.pre_process(image=image, mask=mask)
-
-                item["mask_path"] = mask_path
-                item["image"] = pre_processed["image"]
-                item["mask"] = pre_processed["mask"]
-
-        return item
-
-
 @DATAMODULE_REGISTRY
-class BTech(LightningDataModule):
+class BTech(AnomalibDataModule):
     """BTechDataModule Lightning Data Module."""
 
     def __init__(
         self,
         root: str,
         category: str,
-        # TODO: Remove default values. IAAALD-211
         image_size: Optional[Union[int, Tuple[int, int]]] = None,
         train_batch_size: int = 32,
         test_batch_size: int = 32,
@@ -272,6 +50,7 @@ class BTech(LightningDataModule):
         task: str = "segmentation",
         transform_config_train: Optional[Union[str, A.Compose]] = None,
         transform_config_val: Optional[Union[str, A.Compose]] = None,
+        split_ratio: float = 0.2,
         seed: Optional[int] = None,
         create_validation_set: bool = False,
     ) -> None:
@@ -316,20 +95,20 @@ class BTech(LightningDataModule):
             >>> data["image"].shape, data["mask"].shape
             (torch.Size([32, 3, 256, 256]), torch.Size([32, 256, 256]))
         """
-        super().__init__()
+        super().__init__(
+            task=task,
+            transform_config_train=transform_config_train,
+            transform_config_val=transform_config_val,
+            image_size=image_size,
+            create_validation_set=create_validation_set,
+        )
 
         self.root = root if isinstance(root, Path) else Path(root)
         self.category = category
-        self.dataset_path = self.root / self.category
+        self.path = self.root / self.category
         self.transform_config_train = transform_config_train
         self.transform_config_val = transform_config_val
         self.image_size = image_size
-
-        if self.transform_config_train is not None and self.transform_config_val is None:
-            self.transform_config_val = self.transform_config_train
-
-        self.pre_process_train = PreProcessor(config=self.transform_config_train, image_size=self.image_size)
-        self.pre_process_val = PreProcessor(config=self.transform_config_val, image_size=self.image_size)
 
         self.train_batch_size = train_batch_size
         self.test_batch_size = test_batch_size
@@ -338,12 +117,7 @@ class BTech(LightningDataModule):
         self.create_validation_set = create_validation_set
         self.task = task
         self.seed = seed
-
-        self.train_data: Dataset
-        self.test_data: Dataset
-        if create_validation_set:
-            self.val_data: Dataset
-        self.inference_data: Dataset
+        self.split_ratio = split_ratio
 
     def prepare_data(self) -> None:
         """Download the dataset if not available."""
@@ -386,53 +160,65 @@ class BTech(LightningDataModule):
             logger.info("Cleaning the tar file")
             zip_filename.unlink()
 
-    def setup(self, stage: Optional[str] = None) -> None:
-        """Setup train, validation and test data.
+    def _create_samples(self) -> DataFrame:
+        """Create BTech samples by parsing the BTech data file structure.
 
-        BTech dataset uses BTech dataset structure, which is the reason for
-        using `anomalib.data.btech.BTech` class to get the dataset items.
+        The files are expected to follow the structure:
+            path/to/dataset/category/split/[ok|ko]/image_filename.bmp
+            path/to/dataset/category/ground_truth/ko/mask_filename.png
 
-        Args:
-          stage: Optional[str]:  Train/Val/Test stages. (Default value = None)
+        This function creates a dataframe to store the parsed information based on the following format:
+        |---|---------------|-------|---------|---------------|---------------------------------------|-------------|
+        |   | path          | split | label   | image_path    | mask_path                             | label_index |
+        |---|---------------|-------|---------|---------------|---------------------------------------|-------------|
+        | 0 | datasets/name |  test |  ko     |  filename.png | ground_truth/ko/filename_mask.png     | 1           |
+        |---|---------------|-------|---------|---------------|---------------------------------------|-------------|
 
+        Returns:
+            DataFrame: an output dataframe containing the samples of the dataset.
         """
-        logger.info("Setting up train, validation, test and prediction datasets.")
-        if stage in (None, "fit"):
-            self.train_data = BTechDataset(
-                root=self.root,
-                category=self.category,
-                pre_process=self.pre_process_train,
-                split="train",
-                task=self.task,
-                seed=self.seed,
-                create_validation_set=self.create_validation_set,
-            )
+        samples_list = [
+            (str(self.path),) + filename.parts[-3:]
+            for filename in self.path.glob("**/*")
+            if filename.suffix in (".bmp", ".png")
+        ]
+        if len(samples_list) == 0:
+            raise RuntimeError(f"Found 0 images in {self.path}")
 
-        if self.create_validation_set:
-            self.val_data = BTechDataset(
-                root=self.root,
-                category=self.category,
-                pre_process=self.pre_process_val,
-                split="val",
-                task=self.task,
-                seed=self.seed,
-                create_validation_set=self.create_validation_set,
-            )
+        samples = pd.DataFrame(samples_list, columns=["path", "split", "label", "image_path"])
+        samples = samples[samples.split != "ground_truth"]
 
-        self.test_data = BTechDataset(
-            root=self.root,
-            category=self.category,
-            pre_process=self.pre_process_val,
-            split="test",
-            task=self.task,
-            seed=self.seed,
-            create_validation_set=self.create_validation_set,
+        # Create mask_path column
+        samples["mask_path"] = (
+            samples.path
+            + "/ground_truth/"
+            + samples.label
+            + "/"
+            + samples.image_path.str.rstrip("bmp").str.rstrip(".")
+            + ".png"
         )
 
-        if stage == "predict":
-            self.inference_data = InferenceDataset(
-                path=self.root, image_size=self.image_size, transform_config=self.transform_config_val
-            )
+        # Modify image_path column by converting to absolute path
+        samples["image_path"] = samples.path + "/" + samples.split + "/" + samples.label + "/" + samples.image_path
+
+        # Split the normal images in training set if test set doesn't
+        # contain any normal images. This is needed because AUC score
+        # cannot be computed based on 1-class
+        if sum((samples.split == "test") & (samples.label == "ok")) == 0:
+            samples = split_normal_images_in_train_set(samples, self.split_ratio, self.seed)
+
+        # Good images don't have mask
+        samples.loc[(samples.split == "test") & (samples.label == "ok"), "mask_path"] = ""
+
+        # Create label index for normal (0) and anomalous (1) images.
+        samples.loc[(samples.label == "ok"), "label_index"] = 0
+        samples.loc[(samples.label != "ok"), "label_index"] = 1
+        samples.label_index = samples.label_index.astype(int)
+
+        if self.create_validation_set:
+            samples = create_validation_set_from_test_set(samples, seed=self.seed)
+
+        return samples
 
     def train_dataloader(self) -> TRAIN_DATALOADERS:
         """Get train dataloader."""
@@ -446,9 +232,3 @@ class BTech(LightningDataModule):
     def test_dataloader(self) -> EVAL_DATALOADERS:
         """Get test dataloader."""
         return DataLoader(self.test_data, shuffle=False, batch_size=self.test_batch_size, num_workers=self.num_workers)
-
-    def predict_dataloader(self) -> EVAL_DATALOADERS:
-        """Get predict dataloader."""
-        return DataLoader(
-            self.inference_data, shuffle=False, batch_size=self.test_batch_size, num_workers=self.num_workers
-        )

--- a/anomalib/data/folder.py
+++ b/anomalib/data/folder.py
@@ -14,8 +14,6 @@ from typing import Optional, Tuple, Union
 import albumentations as A
 from pandas.core.frame import DataFrame
 from pytorch_lightning.utilities.cli import DATAMODULE_REGISTRY
-from pytorch_lightning.utilities.types import EVAL_DATALOADERS, TRAIN_DATALOADERS
-from torch.utils.data import DataLoader
 from torchvision.datasets.folder import IMG_EXTENSIONS
 
 from anomalib.data.base import AnomalibDataModule
@@ -194,6 +192,9 @@ class Folder(AnomalibDataModule):
         """
         super().__init__(
             task=task,
+            train_batch_size=train_batch_size,
+            test_batch_size=test_batch_size,
+            num_workers=num_workers,
             transform_config_train=transform_config_train,
             transform_config_val=transform_config_val,
             image_size=image_size,
@@ -225,14 +226,6 @@ class Folder(AnomalibDataModule):
         self.mask_dir = mask_dir
         self.extensions = extensions
         self.split_ratio = split_ratio
-
-        self.transform_config_train = transform_config_train
-        self.transform_config_val = transform_config_val
-        self.image_size = image_size
-
-        self.train_batch_size = train_batch_size
-        self.test_batch_size = test_batch_size
-        self.num_workers = num_workers
 
         self.create_validation_set = create_validation_set
         self.seed = seed
@@ -304,16 +297,3 @@ class Folder(AnomalibDataModule):
             samples = create_validation_set_from_test_set(samples, seed=self.seed, normal_label="normal")
 
         return samples
-
-    def train_dataloader(self) -> TRAIN_DATALOADERS:
-        """Get train dataloader."""
-        return DataLoader(self.train_data, shuffle=True, batch_size=self.train_batch_size, num_workers=self.num_workers)
-
-    def val_dataloader(self) -> EVAL_DATALOADERS:
-        """Get validation dataloader."""
-        dataset = self.val_data if self.create_validation_set else self.test_data
-        return DataLoader(dataset=dataset, shuffle=False, batch_size=self.test_batch_size, num_workers=self.num_workers)
-
-    def test_dataloader(self) -> EVAL_DATALOADERS:
-        """Get test dataloader."""
-        return DataLoader(self.test_data, shuffle=False, batch_size=self.test_batch_size, num_workers=self.num_workers)

--- a/anomalib/data/folder.py
+++ b/anomalib/data/folder.py
@@ -240,6 +240,11 @@ class Folder(AnomalibDataModule):
     def _create_samples(self):
         """Create the dataframe with samples for the Folder dataset.
 
+        The files are expected to follow the structure:
+            path/to/dataset/normal_folder_name/normal_image_name.png
+            path/to/dataset/abnormal_folder_name/abnormal_image_name.png
+
+
         This function creates a dataframe to store the parsed information based on the following format:
         |---|-------------------|--------|-------------|------------------|-------|
         |   | image_path        | label  | label_index | mask_path        | split |
@@ -249,7 +254,6 @@ class Folder(AnomalibDataModule):
 
         Returns:
             DataFrame: an output dataframe containing the samples of the dataset.
-
         """
 
         filenames = []

--- a/anomalib/data/folder.py
+++ b/anomalib/data/folder.py
@@ -440,17 +440,6 @@ class Folder(LightningDataModule):
             self.val_data: Dataset
         self.inference_data: Dataset
 
-        self.samples = make_dataset(
-            normal_dir=self.normal_dir,
-            abnormal_dir=self.abnormal_dir,
-            normal_test_dir=self.normal_test,
-            mask_dir=mask_dir,
-            split_ratio=split_ratio,
-            seed=seed,
-            create_validation_set=create_validation_set,
-            extensions=extensions,
-        )
-
     def setup(self, stage: Optional[str] = None) -> None:
         """Setup train, validation and test data.
 
@@ -458,9 +447,20 @@ class Folder(LightningDataModule):
           stage: Optional[str]:  Train/Val/Test stages. (Default value = None)
 
         """
+        samples = make_dataset(
+            normal_dir=self.normal_dir,
+            abnormal_dir=self.abnormal_dir,
+            normal_test_dir=self.normal_test,
+            mask_dir=self.mask_dir,
+            split_ratio=self.split_ratio,
+            seed=self.seed,
+            create_validation_set=self.create_validation_set,
+            extensions=self.extensions,
+        )
+
         logger.info("Setting up train, validation, test and prediction datasets.")
         if stage in (None, "fit"):
-            train_samples = self.samples[self.samples.split == "train"]
+            train_samples = samples[samples.split == "train"]
             train_samples = train_samples.reset_index(drop=True)
             self.train_data = FolderDataset(
                 samples=train_samples,
@@ -471,7 +471,7 @@ class Folder(LightningDataModule):
             )
 
         if self.create_validation_set:
-            val_samples = self.samples[self.samples.split == "val"]
+            val_samples = samples[samples.split == "val"]
             val_samples = val_samples.reset_index(drop=True)
             self.val_data = FolderDataset(
                 samples=val_samples,
@@ -481,7 +481,7 @@ class Folder(LightningDataModule):
                 task=self.task,
             )
 
-        test_samples = self.samples[self.samples.split == "test"]
+        test_samples = samples[samples.split == "test"]
         test_samples = test_samples.reset_index(drop=True)
         self.test_data = FolderDataset(
             samples=test_samples,

--- a/anomalib/data/folder.py
+++ b/anomalib/data/folder.py
@@ -190,17 +190,6 @@ class Folder(AnomalibDataModule):
             torch.Size([12, 3, 256, 256]) torch.Size([12, 256, 256])
 
         """
-        super().__init__(
-            task=task,
-            train_batch_size=train_batch_size,
-            test_batch_size=test_batch_size,
-            num_workers=num_workers,
-            transform_config_train=transform_config_train,
-            transform_config_val=transform_config_val,
-            image_size=image_size,
-            create_validation_set=create_validation_set,
-        )
-
         if seed is None and normal_test_dir is None:
             raise ValueError(
                 "Both seed and normal_test_dir cannot be None."
@@ -229,6 +218,17 @@ class Folder(AnomalibDataModule):
 
         self.create_validation_set = create_validation_set
         self.seed = seed
+
+        super().__init__(
+            task=task,
+            train_batch_size=train_batch_size,
+            test_batch_size=test_batch_size,
+            num_workers=num_workers,
+            transform_config_train=transform_config_train,
+            transform_config_val=transform_config_val,
+            image_size=image_size,
+            create_validation_set=create_validation_set,
+        )
 
     def _create_samples(self):
         """Create the dataframe with samples for the Folder dataset.

--- a/anomalib/data/mvtec.py
+++ b/anomalib/data/mvtec.py
@@ -109,6 +109,14 @@ class MVTec(AnomalibDataModule):
             >>> data["image"].shape, data["mask"].shape
             (torch.Size([32, 3, 256, 256]), torch.Size([32, 256, 256]))
         """
+        self.root = root if isinstance(root, Path) else Path(root)
+        self.category = category
+        self.path = self.root / self.category
+
+        self.create_validation_set = create_validation_set
+        self.seed = seed
+        self.split_ratio = split_ratio
+
         super().__init__(
             task=task,
             train_batch_size=train_batch_size,
@@ -119,14 +127,6 @@ class MVTec(AnomalibDataModule):
             image_size=image_size,
             create_validation_set=create_validation_set,
         )
-
-        self.root = root if isinstance(root, Path) else Path(root)
-        self.category = category
-        self.path = self.root / self.category
-
-        self.create_validation_set = create_validation_set
-        self.seed = seed
-        self.split_ratio = split_ratio
 
     def prepare_data(self) -> None:
         """Download the dataset if not available."""

--- a/anomalib/data/mvtec.py
+++ b/anomalib/data/mvtec.py
@@ -355,12 +355,6 @@ class MVTec(LightningDataModule):
             self.val_data: Dataset
         self.inference_data: Dataset
 
-        self.samples = make_mvtec_dataset(
-            path=self.root / category,
-            seed=seed,
-            create_validation_set=create_validation_set,
-        )
-
     def prepare_data(self) -> None:
         """Download the dataset if not available."""
         if (self.root / self.category).is_dir():
@@ -395,9 +389,15 @@ class MVTec(LightningDataModule):
           stage: Optional[str]:  Train/Val/Test stages. (Default value = None)
 
         """
+        samples = make_mvtec_dataset(
+            path=self.root / self.category,
+            seed=self.seed,
+            create_validation_set=self.create_validation_set,
+        )
+
         logger.info("Setting up train, validation, test and prediction datasets.")
         if stage in (None, "fit"):
-            train_samples = self.samples[self.samples.split == "train"]
+            train_samples = samples[samples.split == "train"]
             train_samples = train_samples.reset_index(drop=True)
             self.train_data = MVTecDataset(
                 samples=train_samples,
@@ -409,7 +409,7 @@ class MVTec(LightningDataModule):
             )
 
         if self.create_validation_set:
-            val_samples = self.samples[self.samples.split == "val"]
+            val_samples = samples[samples.split == "val"]
             val_samples = val_samples.reset_index(drop=True)
             self.val_data = MVTecDataset(
                 samples=val_samples,
@@ -420,7 +420,7 @@ class MVTec(LightningDataModule):
                 task=self.task,
             )
 
-        test_samples = self.samples[self.samples.split == "test"]
+        test_samples = samples[samples.split == "test"]
         test_samples = test_samples.reset_index(drop=True)
         self.test_data = MVTecDataset(
             samples=test_samples,

--- a/anomalib/data/mvtec.py
+++ b/anomalib/data/mvtec.py
@@ -41,113 +41,14 @@ from pytorch_lightning.utilities.cli import DATAMODULE_REGISTRY
 from pytorch_lightning.utilities.types import EVAL_DATALOADERS, TRAIN_DATALOADERS
 from torch.utils.data import DataLoader
 
-from anomalib.data.base import AnomalibDataModule, AnomalibDataset
+from anomalib.data.base import AnomalibDataModule
 from anomalib.data.utils import DownloadProgressBar, hash_check
 from anomalib.data.utils.split import (
     create_validation_set_from_test_set,
     split_normal_images_in_train_set,
 )
-from anomalib.pre_processing import PreProcessor
 
 logger = logging.getLogger(__name__)
-
-
-def make_mvtec_dataset(
-    path: Path,
-    split_ratio: float = 0.1,
-    seed: Optional[int] = None,
-    create_validation_set: bool = False,
-) -> DataFrame:
-    """Create MVTec AD samples by parsing the MVTec AD data file structure.
-
-    The files are expected to follow the structure:
-        path/to/dataset/split/category/image_filename.png
-        path/to/dataset/ground_truth/category/mask_filename.png
-
-    This function creates a dataframe to store the parsed information based on the following format:
-    |---|---------------|-------|---------|---------------|---------------------------------------|-------------|
-    |   | path          | split | label   | image_path    | mask_path                             | label_index |
-    |---|---------------|-------|---------|---------------|---------------------------------------|-------------|
-    | 0 | datasets/name |  test |  defect |  filename.png | ground_truth/defect/filename_mask.png | 1           |
-    |---|---------------|-------|---------|---------------|---------------------------------------|-------------|
-
-    Args:
-        path (Path): Path to dataset
-        split (str, optional): Dataset split (ie., either train or test). Defaults to None.
-        split_ratio (float, optional): Ratio to split normal training images and add to the
-            test set in case test set doesn't contain any normal images.
-            Defaults to 0.1.
-        seed (int, optional): Random seed to ensure reproducibility when splitting. Defaults to 0.
-        create_validation_set (bool, optional): Boolean to create a validation set from the test set.
-            MVTec AD dataset does not contain a validation set. Those wanting to create a validation set
-            could set this flag to ``True``.
-
-    Example:
-        The following example shows how to get training samples from MVTec AD bottle category:
-
-        >>> root = Path('./MVTec')
-        >>> category = 'bottle'
-        >>> path = root / category
-        >>> path
-        PosixPath('MVTec/bottle')
-
-        >>> samples = make_mvtec_dataset(path, split='train', split_ratio=0.1, seed=0)
-        >>> samples.head()
-           path         split label image_path                           mask_path                   label_index
-        0  MVTec/bottle train good MVTec/bottle/train/good/105.png MVTec/bottle/ground_truth/good/105_mask.png 0
-        1  MVTec/bottle train good MVTec/bottle/train/good/017.png MVTec/bottle/ground_truth/good/017_mask.png 0
-        2  MVTec/bottle train good MVTec/bottle/train/good/137.png MVTec/bottle/ground_truth/good/137_mask.png 0
-        3  MVTec/bottle train good MVTec/bottle/train/good/152.png MVTec/bottle/ground_truth/good/152_mask.png 0
-        4  MVTec/bottle train good MVTec/bottle/train/good/109.png MVTec/bottle/ground_truth/good/109_mask.png 0
-
-    Returns:
-        DataFrame: an output dataframe containing samples for the requested split (ie., train or test)
-    """
-    if seed is None:
-        warnings.warn(
-            "seed is None."
-            " When seed is not set, images from the normal directory are split between training and test dir."
-            " This will lead to inconsistency between runs."
-        )
-
-    samples_list = [(str(path),) + filename.parts[-3:] for filename in path.glob("**/*.png")]
-    if len(samples_list) == 0:
-        raise RuntimeError(f"Found 0 images in {path}")
-
-    samples = pd.DataFrame(samples_list, columns=["path", "split", "label", "image_path"])
-    samples = samples[samples.split != "ground_truth"]
-
-    # Create mask_path column
-    samples["mask_path"] = (
-        samples.path
-        + "/ground_truth/"
-        + samples.label
-        + "/"
-        + samples.image_path.str.rstrip("png").str.rstrip(".")
-        + "_mask.png"
-    )
-
-    # Modify image_path column by converting to absolute path
-    samples["image_path"] = samples.path + "/" + samples.split + "/" + samples.label + "/" + samples.image_path
-
-    # Split the normal images in training set if test set doesn't
-    # contain any normal images. This is needed because AUC score
-    # cannot be computed based on 1-class
-    if sum((samples.split == "test") & (samples.label == "good")) == 0:
-        samples = split_normal_images_in_train_set(samples, split_ratio, seed)
-
-    # Good images don't have mask
-    samples.loc[(samples.split == "test") & (samples.label == "good"), "mask_path"] = ""
-
-    # Create label index for normal (0) and anomalous (1) images.
-    samples.loc[(samples.label == "good"), "label_index"] = 0
-    samples.loc[(samples.label != "good"), "label_index"] = 1
-    samples.label_index = samples.label_index.astype(int)
-
-    if create_validation_set:
-        samples = create_validation_set_from_test_set(samples, seed=seed)
-
-    return samples
 
 
 @DATAMODULE_REGISTRY
@@ -165,6 +66,7 @@ class MVTec(AnomalibDataModule):
         task: str = "segmentation",
         transform_config_train: Optional[Union[str, A.Compose]] = None,
         transform_config_val: Optional[Union[str, A.Compose]] = None,
+        split_ratio: float = 0.2,
         seed: Optional[int] = None,
         create_validation_set: bool = False,
     ) -> None:
@@ -209,7 +111,13 @@ class MVTec(AnomalibDataModule):
             >>> data["image"].shape, data["mask"].shape
             (torch.Size([32, 3, 256, 256]), torch.Size([32, 256, 256]))
         """
-        super().__init__()
+        super().__init__(
+            task=task,
+            transform_config_train=transform_config_train,
+            transform_config_val=transform_config_val,
+            image_size=image_size,
+            create_validation_set=create_validation_set,
+        )
 
         self.root = root if isinstance(root, Path) else Path(root)
         self.category = category
@@ -218,12 +126,6 @@ class MVTec(AnomalibDataModule):
         self.transform_config_val = transform_config_val
         self.image_size = image_size
 
-        if self.transform_config_train is not None and self.transform_config_val is None:
-            self.transform_config_val = self.transform_config_train
-
-        self.pre_process_train = PreProcessor(config=self.transform_config_train, image_size=self.image_size)
-        self.pre_process_val = PreProcessor(config=self.transform_config_val, image_size=self.image_size)
-
         self.train_batch_size = train_batch_size
         self.test_batch_size = test_batch_size
         self.num_workers = num_workers
@@ -231,6 +133,7 @@ class MVTec(AnomalibDataModule):
         self.create_validation_set = create_validation_set
         self.task = task
         self.seed = seed
+        self.split_ratio = split_ratio
 
     def prepare_data(self) -> None:
         """Download the dataset if not available."""
@@ -259,48 +162,69 @@ class MVTec(AnomalibDataModule):
             logger.info("Cleaning the tar file")
             zip_filename.unlink()
 
-    def setup(self, stage: Optional[str] = None) -> None:
-        """Setup train, validation and test data.
+    def _create_samples(self) -> DataFrame:
+        """Create MVTec AD samples by parsing the MVTec AD data file structure.
 
-        Args:
-          stage: Optional[str]:  Train/Val/Test stages. (Default value = None)
+        The files are expected to follow the structure:
+            path/to/dataset/split/category/image_filename.png
+            path/to/dataset/ground_truth/category/mask_filename.png
 
+        This function creates a dataframe to store the parsed information based on the following format:
+        |---|---------------|-------|---------|---------------|---------------------------------------|-------------|
+        |   | path          | split | label   | image_path    | mask_path                             | label_index |
+        |---|---------------|-------|---------|---------------|---------------------------------------|-------------|
+        | 0 | datasets/name |  test |  defect |  filename.png | ground_truth/defect/filename_mask.png | 1           |
+        |---|---------------|-------|---------|---------------|---------------------------------------|-------------|
+
+        Returns:
+            DataFrame: an output dataframe containing the samples of the dataset.
         """
-        samples = make_mvtec_dataset(
-            path=self.root / self.category,
-            seed=self.seed,
-            create_validation_set=self.create_validation_set,
+        if self.seed is None:
+            warnings.warn(
+                "seed is None."
+                " When seed is not set, images from the normal directory are split between training and test dir."
+                " This will lead to inconsistency between runs."
+            )
+
+        path = self.root / self.category
+        samples_list = [(str(path),) + filename.parts[-3:] for filename in path.glob("**/*.png")]
+        if len(samples_list) == 0:
+            raise RuntimeError(f"Found 0 images in {path}")
+
+        samples = pd.DataFrame(samples_list, columns=["path", "split", "label", "image_path"])
+        samples = samples[samples.split != "ground_truth"]
+
+        # Create mask_path column
+        samples["mask_path"] = (
+            samples.path
+            + "/ground_truth/"
+            + samples.label
+            + "/"
+            + samples.image_path.str.rstrip("png").str.rstrip(".")
+            + "_mask.png"
         )
 
-        logger.info("Setting up train, validation, test and prediction datasets.")
-        if stage in (None, "fit"):
-            train_samples = samples[samples.split == "train"]
-            train_samples = train_samples.reset_index(drop=True)
-            self.train_data = AnomalibDataset(
-                samples=train_samples,
-                pre_process=self.pre_process_train,
-                split="train",
-                task=self.task,
-            )
+        # Modify image_path column by converting to absolute path
+        samples["image_path"] = samples.path + "/" + samples.split + "/" + samples.label + "/" + samples.image_path
+
+        # Split the normal images in training set if test set doesn't
+        # contain any normal images. This is needed because AUC score
+        # cannot be computed based on 1-class
+        if sum((samples.split == "test") & (samples.label == "good")) == 0:
+            samples = split_normal_images_in_train_set(samples, self.split_ratio, self.seed)
+
+        # Good images don't have mask
+        samples.loc[(samples.split == "test") & (samples.label == "good"), "mask_path"] = ""
+
+        # Create label index for normal (0) and anomalous (1) images.
+        samples.loc[(samples.label == "good"), "label_index"] = 0
+        samples.loc[(samples.label != "good"), "label_index"] = 1
+        samples.label_index = samples.label_index.astype(int)
 
         if self.create_validation_set:
-            val_samples = samples[samples.split == "val"]
-            val_samples = val_samples.reset_index(drop=True)
-            self.val_data = AnomalibDataset(
-                samples=val_samples,
-                pre_process=self.pre_process_val,
-                split="val",
-                task=self.task,
-            )
+            samples = create_validation_set_from_test_set(samples, seed=self.seed)
 
-        test_samples = samples[samples.split == "test"]
-        test_samples = test_samples.reset_index(drop=True)
-        self.test_data = AnomalibDataset(
-            samples=test_samples,
-            pre_process=self.pre_process_val,
-            split="test",
-            task=self.task,
-        )
+        return samples
 
     def train_dataloader(self) -> TRAIN_DATALOADERS:
         """Get train dataloader."""

--- a/anomalib/utils/metrics/adaptive_threshold.py
+++ b/anomalib/utils/metrics/adaptive_threshold.py
@@ -3,6 +3,8 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
+
 import torch
 from torchmetrics import PrecisionRecallCurve
 
@@ -32,6 +34,14 @@ class AdaptiveThreshold(PrecisionRecallCurve):
         precision: torch.Tensor
         recall: torch.Tensor
         thresholds: torch.Tensor
+
+        if not any(1 in batch for batch in self.target):
+            warnings.warn(
+                "The validation set does not contain any anomalous images. As a result, the adaptive threshold will "
+                "take the value of the highest anomaly score observed in the normal validation images, which may lead "
+                "to poor predictions. For a more reliable adaptive threshold computation, please add some anomalous "
+                "images to the validation set."
+            )
 
         precision, recall, thresholds = super().compute()
         f1_score = (2 * precision * recall) / (precision + recall + 1e-10)

--- a/tools/train.py
+++ b/tools/train.py
@@ -63,7 +63,7 @@ def train():
     load_model_callback = LoadModelCallback(weights_path=trainer.checkpoint_callback.best_model_path)
     trainer.callbacks.insert(0, load_model_callback)
 
-    if datamodule.test_data.contains_anomalous_images():
+    if datamodule.contains_anomalous_images("test"):
         logger.info("Testing the model.")
         trainer.test(model=model, datamodule=datamodule)
     else:

--- a/tools/train.py
+++ b/tools/train.py
@@ -63,8 +63,11 @@ def train():
     load_model_callback = LoadModelCallback(weights_path=trainer.checkpoint_callback.best_model_path)
     trainer.callbacks.insert(0, load_model_callback)
 
-    logger.info("Testing the model.")
-    trainer.test(model=model, datamodule=datamodule)
+    if datamodule.test_data.contains_anomalous_images():
+        logger.info("Testing the model.")
+        trainer.test(model=model, datamodule=datamodule)
+    else:
+        logger.info("No anomalous images found in dataset. Skipping test stage.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

- This PR refactors the data modules to reduce duplication.
- The `AnomalibDataset` class was introduced, which replaces the individual dataset classes.
- The base class `AnomalibDataModule` was introduced, and the `setup` method was moved from the concrete subclasses to the new base class.
- The `make_mvtec_dataset`, `make_btech_dataset` and `make_dataset` functions are replaced by the `_create_samples` method. The implementation of this method differs between the individual data module classes.

- The refactor also makes it possible to train when no anomalous images are present in the dataset. In this case, Anomalib will not run the test stage after training, so no performance metrics are reported. The user will be notified about this through a logging message.

- Fixes https://github.com/openvinotoolkit/anomalib/issues/277

## Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which refactors the code base)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
