### PR TITLE
Add map_location when loading the weights

### DIFF
--- a/anomalib/utils/callbacks/model_loader.py
+++ b/anomalib/utils/callbacks/model_loader.py
@@ -27,7 +27,7 @@ class LoadModelCallback(Callback):
         Loads the model weights from ``weights_path`` into the PyTorch module.
         """
         logger.info("Loading the model from %s", self.weights_path)
-        pl_module.load_state_dict(torch.load(self.weights_path)["state_dict"])
+        pl_module.load_state_dict(torch.load(self.weights_path, map_location=pl_module.device)["state_dict"])
 
     def on_predict_start(self, _trainer, pl_module: AnomalyModule) -> None:
         """Call when inference begins.
@@ -35,4 +35,4 @@ class LoadModelCallback(Callback):
         Loads the model weights from ``weights_path`` into the PyTorch module.
         """
         logger.info("Loading the model from %s", self.weights_path)
-        pl_module.load_state_dict(torch.load(self.weights_path)["state_dict"])
+        pl_module.load_state_dict(torch.load(self.weights_path, map_location=pl_module.device)["state_dict"])


### PR DESCRIPTION
# Description

- This PR adds map_location when loading weights. This is because the current approach does not consider the case where a model is trained on gpu and tested on cpu, or vice-versa.

- Fixes #532 

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
