### PR TITLE
Add patchcore to openvino export test + upgrade lightning

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,6 +12,6 @@ pandas>=1.1.0
 pytorch-lightning>=1.6.0,<1.7.0
 timm==0.5.4
 torchmetrics>=0.9.1,<=0.9.3
-torchvision>=0.9.1,<=0.12.0
-torchtext>=0.9.1,<=0.12.0
+torchvision>=0.9.1,<=0.13.0
+torchtext>=0.9.1,<=0.13.0
 wandb==0.12.17

--- a/tests/pre_merge/deploy/test_inferencer.py
+++ b/tests/pre_merge/deploy/test_inferencer.py
@@ -80,7 +80,7 @@ class TestInferencers:
 
     @pytest.mark.parametrize(
         "model_name",
-        ["dfm", "draem", "ganomaly", "padim", "stfpm"],
+        ["dfm", "draem", "ganomaly", "padim", "patchcore", "stfpm"],
     )
     @TestDataset(num_train=20, num_test=1, path=get_dataset_path(), use_mvtec=False)
     def test_openvino_inference(self, model_name: str, category: str = "shapes", path: str = "./datasets/MVTec"):


### PR DESCRIPTION
# Description

We had limited torchvision to 0.12.0 because it ended up installing torch 1.12.0. (PR https://github.com/openvinotoolkit/anomalib/pull/396). From my experiments right now everything seems to be working. The tests pass locally. So hopefully this should address patchcore onnx export (https://github.com/openvinotoolkit/anomalib/issues/440) for those using torch==1.12.0 