### PR TITLE
✨ Replace keys from benchmarking script

### DIFF
--- a/docs/source/tutorials/benchmarking.rst
+++ b/docs/source/tutorials/benchmarking.rst
@@ -44,6 +44,39 @@ This configuration computes the throughput and performance metrics on CPU and GP
     seed: 0
     image_size: 256
 
+You can also replace the keys from within the benchmarking script. To do this just use the value instead of passing an array. Taking the example of the folder dataset above, the configuration file can be modified as.
+
+.. code-block:: yaml
+
+  seed: 42
+  compute_openvino: false
+  hardware:
+    - cpu
+    - gpu
+  writer:
+    - comet
+    - wandb
+    - tensorboard
+  grid_search:
+    dataset:
+      name: hazelnut
+      format: folder
+      path: path/hazelnut_toy
+      normal_dir: good # name of the folder containing normal images.
+      abnormal_dir: colour # name of the folder containing abnormal images.
+      normal_test_dir: null
+      task: segmentation # classification or segmentation
+      mask: path/hazelnut_toy/mask/colour
+      extensions: .jpg
+      split_ratio: 0.2
+      category:
+        - colour
+        - crack
+      image_size: [128, 256]
+    model_name:
+      - padim
+      - stfpm
+
 By default, ``compute_openvino`` is set to ``False`` to support instances where OpenVINO requirements are not installed in the environment. Once installed, this flag can be set to ``True`` to get the throughput on OpenVINO optimized models. The ``writer`` parameter is optional and can be set to ``writer: []`` in case the user only requires a csv file without logging to each respective logger. It is a good practice to set a value of seed to ensure reproducibility across runs and thus, is set to a non-zero value by default.
 
 Once a configuration is decided, benchmarking can easily be performed by calling

--- a/docs/source/tutorials/benchmarking.rst
+++ b/docs/source/tutorials/benchmarking.rst
@@ -44,7 +44,7 @@ This configuration computes the throughput and performance metrics on CPU and GP
     seed: 0
     image_size: 256
 
-You can also replace the keys from within the benchmarking script. To do this just use the value instead of passing an array. Taking the example of the folder dataset above, the configuration file can be modified as.
+Additionally, the keys can be replaced from the benchmarking script. To do this just use the value instead of passing an array. Taking the example of the folder dataset above, the configuration file can be modified as.
 
 .. code-block:: yaml
 

--- a/docs/source/tutorials/benchmarking.rst
+++ b/docs/source/tutorials/benchmarking.rst
@@ -44,7 +44,7 @@ This configuration computes the throughput and performance metrics on CPU and GP
     seed: 0
     image_size: 256
 
-Additionally, the keys can be replaced from the benchmarking script. To do this just use the value instead of passing an array. Taking the example of the folder dataset above, the configuration file can be modified as.
+Additionally, it is possible to pass a single value instead of an array for any specific parameter. This will overwrite the parameter in each of the model configs and thereby ensures that the parameter is kept constant between all runs in the sweep. For example, to ensure that the same dataset is used between runs the configuration file can be modified as shown below.
 
 .. code-block:: yaml
 

--- a/tests/pre_merge/utils/sweep/__init__.py
+++ b/tests/pre_merge/utils/sweep/__init__.py
@@ -1,15 +1,4 @@
 """Test sweep utils."""
 
 # Copyright (C) 2022 Intel Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions
-# and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/pre_merge/utils/sweep/__init__.py
+++ b/tests/pre_merge/utils/sweep/__init__.py
@@ -1,0 +1,15 @@
+"""Test sweep utils."""
+
+# Copyright (C) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.

--- a/tests/pre_merge/utils/sweep/test_config.py
+++ b/tests/pre_merge/utils/sweep/test_config.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
 from omegaconf import DictConfig
 
 from anomalib.utils.sweep.config import get_run_config, set_in_nested_config

--- a/tests/pre_merge/utils/sweep/test_config.py
+++ b/tests/pre_merge/utils/sweep/test_config.py
@@ -1,0 +1,53 @@
+"""Test sweep config utils."""
+
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from omegaconf import DictConfig
+
+from anomalib.utils.sweep.config import get_run_config, set_in_nested_config
+
+
+class TestSweepConfig:
+    def test_get_run_config(self):
+        """Test whether the run config is returned correctly and patches the keys which have only one value."""
+        dummy_config = DictConfig(
+            {
+                "parent1": {"child1": ["a", "b"], "child2": [1, 2]},
+                "parent2": ["model1", "model2"],
+                "parent3": "replacement_value",
+            }
+        )
+        run_config = list(get_run_config(dummy_config))
+        expected_value = [
+            {"parent1.child1": "a", "parent1.child2": 1, "parent2": "model1", "parent3": "replacement_value"},
+            {"parent1.child1": "a", "parent1.child2": 1, "parent2": "model2", "parent3": "replacement_value"},
+            {"parent1.child1": "a", "parent1.child2": 2, "parent2": "model1", "parent3": "replacement_value"},
+            {"parent1.child1": "a", "parent1.child2": 2, "parent2": "model2", "parent3": "replacement_value"},
+            {"parent1.child1": "b", "parent1.child2": 1, "parent2": "model1", "parent3": "replacement_value"},
+            {"parent1.child1": "b", "parent1.child2": 1, "parent2": "model2", "parent3": "replacement_value"},
+            {"parent1.child1": "b", "parent1.child2": 2, "parent2": "model1", "parent3": "replacement_value"},
+            {"parent1.child1": "b", "parent1.child2": 2, "parent2": "model2", "parent3": "replacement_value"},
+        ]
+        assert run_config == expected_value
+
+    def set_in_nested_config(self):
+        dummy_config = DictConfig(
+            {"parent1": {"child1": ["a", "b", "c"], "child2": [1, 2, 3]}, "parent2": ["model1", "model2"]}
+        )
+
+        model_config = DictConfig(
+            {
+                "parent1": {
+                    "child1": "e",
+                    "child2": 4,
+                },
+                "parent3": False,
+            }
+        )
+
+        for run_config in get_run_config(dummy_config):
+            for param in run_config.keys():
+                set_in_nested_config(model_config, param.split("."), run_config[param])
+        assert model_config == {"parent1": {"child1": "a", "child2": 1}, "parent3": False, "parent2": "model1"}


### PR DESCRIPTION
# Description

- Replacing keys from benchmarking script will help set dataset from the run configuration. This ensures that all models have the same parameters for dataset.
- Fixes #300 