### PR TITLE
Optimized inference with onnx for patchcore.

### DIFF
--- a/anomalib/models/patchcore/torch_model.py
+++ b/anomalib/models/patchcore/torch_model.py
@@ -38,7 +38,7 @@ class PatchcoreModel(DynamicBufferModule, nn.Module):
         self.num_neighbors = num_neighbors
 
         self.feature_extractor = FeatureExtractor(backbone=self.backbone, pre_trained=pre_trained, layers=self.layers)
-        self.feature_pooler = torch.nn.AvgPool2d(3, 1, 1)
+        self.feature_pooler = torch.nn.AvgPool2d(3, 1, 1, count_include_pad=False)
         self.anomaly_map_generator = AnomalyMapGenerator(input_size=input_size)
 
         self.register_buffer("memory_bank", Tensor())


### PR DESCRIPTION
results inferenced with onnx is inconsistent with torch, especially the border.

# Description

- fix c++ inference with onnx.

  before this PR, out:
![image](https://user-images.githubusercontent.com/37766207/198214271-2dc17b16-3f05-4bea-974f-9fc1777ae7ba.png)

  after this PR, out:
![image](https://user-images.githubusercontent.com/37766207/198214461-2eee04e1-e8a7-453c-affa-d8705f472993.png)


## Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
