### PR TITLE
Jpcbertoldo/padim config improvements

### DIFF
--- a/anomalib/config/config.py
+++ b/anomalib/config/config.py
@@ -6,6 +6,7 @@
 # TODO: This would require a new design.
 # TODO: https://jira.devtools.intel.com/browse/IAAALD-149
 
+from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, Union
 from warnings import warn
@@ -140,6 +141,19 @@ def get_configurable_parameters(
 
     # Project Configs
     project_path = Path(config.project.path) / config.model.name / config.dataset.name
+
+    if "unique_dir" not in config.project.keys():
+        warn("config.project.unique_dir not found config file. Setting to False for backward compatibility")
+        config.project.unique_dir = False  # backward compatibility
+
+    if config.project.unique_dir:
+        project_path = project_path / datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    else:
+        warn(
+            "config.project.unique_dir is set to False. "
+            "This does not ensure that your results will be written in an empty directory and you may overwrite files."
+        )
+
     if config.dataset.format.lower() in ("btech", "mvtec"):
         project_path = project_path / config.dataset.category
 

--- a/anomalib/data/folder.py
+++ b/anomalib/data/folder.py
@@ -139,6 +139,13 @@ def make_dataset(
             if row.label_index == 1:
                 samples.loc[index, "mask_path"] = str(mask_dir / row.image_path.name)
 
+    # make sure all the files exist, dirs_str is used for error message
+    dirs_str = f"normal_dir={normal_dir}, abnormal_dir {abnormal_dir}, normal_test_dir={normal_test_dir}"
+    assert samples.image_path.apply(lambda x: x.exists()).all(), f"missing image files, {dirs_str}"
+    assert samples.mask_path.apply(
+        lambda x: Path(x).exists() if x != "" else True
+    ).all(), f"missing mask files, mask_dir={mask_dir}"
+
     # Ensure the pathlib objects are converted to str.
     # This is because torch dataloader doesn't like pathlib.
     samples = samples.astype({"image_path": "str"})
@@ -430,6 +437,8 @@ class Folder(LightningDataModule):
         if normal_test_dir:
             self.normal_test = self.root / normal_test_dir
         self.mask_dir = mask_dir
+        if mask_dir:
+            self.mask_dir = self.root / mask_dir
         self.extensions = extensions
         self.split_ratio = split_ratio
 

--- a/anomalib/models/padim/lightning_model.py
+++ b/anomalib/models/padim/lightning_model.py
@@ -7,7 +7,7 @@ Paper https://arxiv.org/abs/2011.08785
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import List, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import torch
 from omegaconf import DictConfig, ListConfig
@@ -39,6 +39,7 @@ class Padim(AnomalyModule):
         input_size: Tuple[int, int],
         backbone: str,
         pre_trained: bool = True,
+        n_features: Optional[int] = None,
     ):
         super().__init__()
 
@@ -48,6 +49,7 @@ class Padim(AnomalyModule):
             backbone=backbone,
             pre_trained=pre_trained,
             layers=layers,
+            n_features=n_features,
         ).eval()
 
         self.stats: List[Tensor] = []
@@ -119,6 +121,7 @@ class PadimLightning(Padim):
             layers=hparams.model.layers,
             backbone=hparams.model.backbone,
             pre_trained=hparams.model.pre_trained,
+            n_features=hparams.model.n_features if "n_features" in hparams.model else None,
         )
         self.hparams: Union[DictConfig, ListConfig]  # type: ignore
         self.save_hyperparameters(hparams)


### PR DESCRIPTION
# Description

Fix #662 by creating the parameter `n_features` (nb of features/axes retained by the dimension reduction).

I also made it possible to use a custom backbone without modifying the source code.
This was limited by this hardcoded dict

![image](https://user-images.githubusercontent.com/24547377/199137692-66d2c24b-3cb9-4acd-af03-9a60fbb86820.png)

If the backbone was not in the dict then the `orig_dims` and `emb_scale` could not be set.
These two don't need to be hardcoded, I made it be deduced from a dryrun feature extraction.

## Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://openvinotoolkit.github.io/anomalib/guides/using_pre_commit.html#pre-commit-hooks) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
