### PR TITLE
make it possible to use tox pre_merge to test single file

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     -r{toxinidir}/requirements/openvino.txt
 commands =
     coverage erase
-    coverage run --include=anomalib/* -m pytest tests/pre_merge/ -ra --showlocals
+    coverage run --include=anomalib/* -m pytest {posargs:tests/pre_merge/} -ra --showlocals
     ; https://github.com/openvinotoolkit/anomalib/issues/94
     coverage report -m --fail-under=85
     coverage xml -o {toxworkdir}/coverage.xml


### PR DESCRIPTION
Can we do this, please?

It allows one to pass command line arguments to tox while keeping the previous behaviour as default.

Source: [https://stackoverflow.com/a/35287375/9582881](https://stackoverflow.com/a/35287375/9582881)

So `tox -e pre_merge` will run all the tests in `tests/pre_merge`, like currently.

And `tox -e pre_merge tests/pre_merge/path/to/single/test_single.py` will only run the tests in `test_single.py`.
