### PR TITLE
🐞 Fix folder dataset for classification tasks

### DIFF
--- a/anomalib/data/folder.py
+++ b/anomalib/data/folder.py
@@ -139,11 +139,11 @@ def make_dataset(
             if row.label_index == 1:
                 samples.loc[index, "mask_path"] = str(mask_dir / row.image_path.name)
 
-    # make sure all the files exist
-    # samples.image_path does NOT need to be checked because we build the df based on that
-    assert samples.mask_path.apply(
-        lambda x: Path(x).exists() if x != "" else True
-    ).all(), f"missing mask files, mask_dir={mask_dir}"
+        # make sure all the files exist
+        # samples.image_path does NOT need to be checked because we build the df based on that
+        assert samples.mask_path.apply(
+            lambda x: Path(x).exists() if x != "" else True
+        ).all(), f"missing mask files, mask_dir={mask_dir}"
 
     # Ensure the pathlib objects are converted to str.
     # This is because torch dataloader doesn't like pathlib.


### PR DESCRIPTION
# Description

PR #660 introduced a check to ensure mask paths are correct. However, this check is also done even if `mask_dir` is not provided. This causes an error for classification tasks, where a mask path is not given.

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
