### PR TITLE
update torchmetrics to catch bug fix

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ opencv-python>=4.5.3.56
 pandas>=1.1.0
 pytorch-lightning>=1.6.0,<1.7.0
 timm==0.5.4
-torchmetrics>=0.9.1,<=0.9.3
+torchmetrics>=0.10.3
 torchvision>=0.9.1,<=0.13.0
 torchtext>=0.9.1,<=0.13.0
 wandb==0.12.17


### PR DESCRIPTION
# Description

I had issues to compute `AUROC` on a CPU in a use case where I didn't have enough memory in the GPU.

I opened an issue in tochmetrics: https://github.com/Lightning-AI/metrics/issues/1323

and it has been fixed: https://github.com/Lightning-AI/metrics/pull/1333

Could we upgrade torchmetrics to catch this bug fix?

Version `0.10.3` is not released yet but should come next week. 

For future ref: https://github.com/Lightning-AI/metrics/tags

Disclaimer: I have not tried to run the pre-merge tests locally because apparently there are issues with them (https://github.com/openvinotoolkit/anomalib/issues/704)

## Changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
