### PR TITLE
Add support for Detection task type

### DIFF
--- a/anomalib/data/utils/__init__.py
+++ b/anomalib/data/utils/__init__.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+from .boxes import boxes_to_anomaly_maps, boxes_to_masks, masks_to_boxes
 from .download import DownloadProgressBar, hash_check
 from .generators import random_2d_perlin
 from .image import (
@@ -25,4 +26,7 @@ __all__ = [
     "concatenate_datasets",
     "Split",
     "ValSplitMode",
+    "masks_to_boxes",
+    "boxes_to_masks",
+    "boxes_to_anomaly_maps",
 ]

--- a/anomalib/data/utils/boxes.py
+++ b/anomalib/data/utils/boxes.py
@@ -1,0 +1,87 @@
+"""Helper functions for processing bounding box detections and annotations."""
+
+from typing import List, Tuple
+
+import torch
+from torch import Tensor
+
+from anomalib.utils.cv import connected_components_cpu, connected_components_gpu
+
+
+def masks_to_boxes(masks: Tensor) -> List[Tensor]:
+    """Convert a batch of segmentation masks to bounding box coordinates.
+
+    Args:
+        masks (Tensor): Input tensor of shape (B, 1, H, W), (B, H, W) or (H, W)
+
+    Returns:
+        List[Tensor]: A list of length B where each element is a tensor of shape (N, 4) containing the bounding box
+            coordinates of the objects in the masks in xyxy format.
+    """
+    masks = masks.view(
+        (
+            -1,
+            1,
+        )
+        + masks.shape[-2:]
+    )  # reshape to (B, 1, H, W)
+    masks = masks.float()
+
+    if masks.is_cuda:
+        batch_comps = connected_components_gpu(masks).squeeze(1)
+    else:
+        batch_comps = connected_components_cpu(masks).squeeze(1)
+
+    batch_boxes = []
+    for im_comps in batch_comps:
+        labels = torch.unique(im_comps)
+        im_boxes = []
+        for label in labels[labels != 0]:
+            y_loc, x_loc = torch.where(im_comps == label)
+            im_boxes.append(Tensor([torch.min(x_loc), torch.min(y_loc), torch.max(x_loc), torch.max(y_loc)]))
+        batch_boxes.append(torch.stack(im_boxes) if len(im_boxes) > 0 else torch.empty((0, 4)))
+    return batch_boxes
+
+
+def boxes_to_masks(boxes: List[Tensor], image_size: Tuple[int, int]) -> Tensor:
+    """Convert bounding boxes to segmentations masks.
+
+    Args:
+        boxes (List[Tensor]): A list of length B where each element is a tensor of shape (N, 4) containing the bounding
+            box coordinates of the regions of interest in xyxy format.
+        image_size (Tuple[int, int]): Image size of the output masks in (H, W) format.
+
+    Returns:
+        Tensor: Tensor of shape (B, H, W) in which each slice is a binary mask showing the pixels contained by a
+            bounding box.
+    """
+    masks = torch.zeros((len(boxes),) + image_size)
+    for im_idx, im_boxes in enumerate(boxes):
+        for box in im_boxes:
+            x_1, y_1, x_2, y_2 = box.int()
+            masks[im_idx, y_1:y_2, x_1:x_2] = 1
+    return masks
+
+
+def boxes_to_anomaly_maps(boxes: Tensor, scores: Tensor, image_size: Tuple[int, int]) -> Tensor:
+    """Convert bounding box coordinates to anomaly heatmaps.
+
+    Args:
+        boxes (List[Tensor]): A list of length B where each element is a tensor of shape (N, 4) containing the bounding
+            box coordinates of the regions of interest in xyxy format.
+        scores (List[Tensor]): A list of length B where each element is a 1D tensor of length N containing the anomaly
+            scores for each region of interest.
+        image_size (Tuple[int, int]): Image size of the output masks in (H, W) format.
+
+    Returns:
+        Tensor: Tensor of shape (B, H, W). The pixel locations within each bounding box are collectively assigned the
+            anomaly score of the bounding box. In the case of overlapping bounding boxes, the highest score is used.
+    """
+    anomaly_maps = torch.zeros((len(boxes),) + image_size).to(boxes[0].device)
+    for im_idx, (im_boxes, im_scores) in enumerate(zip(boxes, scores)):
+        im_map = torch.zeros((im_boxes.shape[0],) + image_size)
+        for box_idx, (box, score) in enumerate(zip(im_boxes, im_scores)):
+            x_1, y_1, x_2, y_2 = box.int()
+            im_map[box_idx, y_1:y_2, x_1:x_2] = score
+            anomaly_maps[im_idx], _ = im_map.max(dim=0)
+    return anomaly_maps

--- a/anomalib/models/components/base/anomaly_module.py
+++ b/anomalib/models/components/base/anomaly_module.py
@@ -5,14 +5,16 @@
 
 import logging
 from abc import ABC
-from typing import Any, List, Optional, OrderedDict
+from typing import Any, Dict, List, Optional, OrderedDict
 from warnings import warn
 
 import pytorch_lightning as pl
+import torch
 from pytorch_lightning.callbacks.base import Callback
 from torch import Tensor, nn
 from torchmetrics import Metric
 
+from anomalib.data.utils import boxes_to_anomaly_maps, boxes_to_masks, masks_to_boxes
 from anomalib.post_processing import ThresholdMethod
 from anomalib.utils.metrics import (
     AnomalibMetricCollection,
@@ -82,6 +84,8 @@ class AnomalyModule(pl.LightningModule, ABC):
         outputs["pred_labels"] = outputs["pred_scores"] >= self.image_threshold.value
         if "anomaly_maps" in outputs.keys():
             outputs["pred_masks"] = outputs["anomaly_maps"] >= self.pixel_threshold.value
+            if "pred_boxes" not in outputs.keys():
+                outputs["pred_boxes"] = masks_to_boxes(outputs["pred_masks"])
         return outputs
 
     def test_step(self, batch, _):  # pylint: disable=arguments-differ
@@ -155,15 +159,28 @@ class AnomalyModule(pl.LightningModule, ABC):
     def _post_process(outputs):
         """Compute labels based on model predictions."""
         if "pred_scores" not in outputs and "anomaly_maps" in outputs:
+            # infer image scores from anomaly maps
             outputs["pred_scores"] = (
                 outputs["anomaly_maps"].reshape(outputs["anomaly_maps"].shape[0], -1).max(dim=1).values
             )
+        elif "pred_scores" not in outputs and "boxes_scores" in outputs:
+            # infer image score from bbox confidence scores
+            outputs["pred_scores"] = torch.stack([scores.max() for scores in outputs["boxes_scores"]])
+        if "pred_boxes" in outputs and "anomaly_maps" not in outputs:
+            # create anomaly maps from bbox predictions for thresholding and evaluation
+            image_size = tuple(outputs["image"].shape[-2:])
+            outputs["anomaly_maps"] = boxes_to_anomaly_maps(outputs["pred_boxes"], outputs["boxes_scores"], image_size)
+            outputs["mask"] = boxes_to_masks(outputs["boxes"], image_size)
 
-    @staticmethod
-    def _outputs_to_cpu(output):
-        for key, value in output.items():
-            if isinstance(value, Tensor):
-                output[key] = value.cpu()
+    def _outputs_to_cpu(self, output):
+        if isinstance(output, Dict):
+            for key, value in output.items():
+                output[key] = self._outputs_to_cpu(value)
+        elif isinstance(output, List):
+            output = [self._outputs_to_cpu(item) for item in output]
+        elif isinstance(output, Tensor):
+            output = output.cpu()
+        return output
 
     def _log_metrics(self):
         """Log computed performance metrics."""

--- a/anomalib/post_processing/post_process.py
+++ b/anomalib/post_processing/post_process.py
@@ -151,3 +151,22 @@ def compute_mask(anomaly_map: np.ndarray, threshold: float, kernel_size: int = 4
     mask *= 255
 
     return mask
+
+
+def draw_boxes(image: np.ndarray, boxes: np.ndarray, is_ground_truth: bool = False) -> np.ndarray:
+    """Draw bounding boxes on an image.
+
+    Args:
+        image (np.ndarray): Source image.
+        boxes (np.nparray): 2D array of shape (N, 4) where each row contains the xyxy coordinates of a bounding box.
+        is_ground_truth (bool): Flag indicating if the boxes are ground truth. When true, boxes will be drawn in red,
+            otherwise in blue.
+
+    Returns:
+        np.ndarray: Image showing the bounding boxes drawn on top of the source image.
+    """
+    color = (255, 0, 0) if is_ground_truth else (0, 0, 255)
+    for box in boxes:
+        x_1, y_1, x_2, y_2 = box.astype(np.int)
+        image = cv2.rectangle(image, (x_1, y_1), (x_2, y_2), color=color, thickness=2)
+    return image

--- a/anomalib/utils/callbacks/min_max_normalization.py
+++ b/anomalib/utils/callbacks/min_max_normalization.py
@@ -6,6 +6,7 @@
 from typing import Any, Dict, Optional
 
 import pytorch_lightning as pl
+import torch
 from pytorch_lightning import Callback
 from pytorch_lightning.utilities.cli import CALLBACK_REGISTRY
 from pytorch_lightning.utilities.types import STEP_OUTPUT
@@ -46,10 +47,14 @@ class MinMaxNormalizationCallback(Callback):
         _dataloader_idx: int,
     ) -> None:
         """Called when the validation batch ends, update the min and max observed values."""
-        if "anomaly_maps" in outputs.keys():
+        if "anomaly_maps" in outputs:
             pl_module.normalization_metrics(outputs["anomaly_maps"])
-        else:
+        elif "boxes_scores" in outputs:
+            pl_module.normalization_metrics(torch.cat(outputs["boxes_scores"]))
+        elif "pred_scores" in outputs:
             pl_module.normalization_metrics(outputs["pred_scores"])
+        else:
+            raise ValueError("No values found for normalization, provide anomaly maps, bbox scores, or image scores")
 
     def on_test_batch_end(
         self,

--- a/anomalib/utils/callbacks/visualizer/visualizer_base.py
+++ b/anomalib/utils/callbacks/visualizer/visualizer_base.py
@@ -37,7 +37,7 @@ class BaseVisualizerCallback(Callback):
         if mode not in ["full", "simple"]:
             raise ValueError(f"Unknown visualization mode: {mode}. Please choose one of ['full', 'simple']")
         self.mode = mode
-        if task not in ["classification", "segmentation"]:
+        if task not in ["classification", "segmentation", "detection"]:
             raise ValueError(f"Unknown task type: {mode}. Please choose one of ['classification', 'segmentation']")
         self.task = task
         self.inputs_are_normalized = inputs_are_normalized

--- a/anomalib/utils/cv/__init__.py
+++ b/anomalib/utils/cv/__init__.py
@@ -1,0 +1,8 @@
+"""Anomalib operators."""
+
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from .connected_components import connected_components_cpu, connected_components_gpu
+
+__all__ = ["connected_components_cpu", "connected_components_gpu"]

--- a/anomalib/utils/cv/connected_components.py
+++ b/anomalib/utils/cv/connected_components.py
@@ -1,0 +1,48 @@
+"""Connected component labeling."""
+
+import cv2
+import numpy as np
+import torch
+from kornia.contrib import connected_components
+from torch import Tensor
+
+
+def connected_components_gpu(binary_input: Tensor, num_iterations: int = 1000) -> Tensor:
+    """Perform connected component labeling on GPU and remap the labels from 0 to N.
+
+    Args:
+        binary_input (Tensor): Binary input data from which we want to extract connected components (Bx1xHxW)
+        num_iterations (int): Number of iterations used in the connected component computation.
+
+    Returns:
+        Tensor: Components labeled from 0 to N.
+    """
+    components = connected_components(binary_input, num_iterations=num_iterations)
+
+    # remap component values from 0 to N
+    labels = components.unique()
+    for new_label, old_label in enumerate(labels):
+        components[components == old_label] = new_label
+
+    return components.int()
+
+
+def connected_components_cpu(image: Tensor) -> Tensor:
+    """Connected component labeling on CPU.
+
+    Args:
+        image (Tensor): Binary input data from which we want to extract connected components (Bx1xHxW)
+
+    Returns:
+        Tensor: Components labeled from 0 to N.
+    """
+    components = torch.zeros_like(image)
+    label_idx = 1
+    for i, mask in enumerate(image):
+        mask = mask.squeeze().numpy().astype(np.uint8)
+        _, comps = cv2.connectedComponents(mask)
+        # remap component values to make sure every component has a unique value when outputs are concatenated
+        for label in np.unique(comps)[1:]:
+            components[i, 0, ...][np.where(comps == label)] = label_idx
+            label_idx += 1
+    return components.int()

--- a/anomalib/utils/metrics/pro.py
+++ b/anomalib/utils/metrics/pro.py
@@ -5,14 +5,13 @@
 
 from typing import List
 
-import cv2
-import numpy as np
 import torch
-from kornia.contrib import connected_components
 from torch import Tensor
 from torchmetrics import Metric
 from torchmetrics.functional import recall
 from torchmetrics.utilities.data import dim_zero_cat
+
+from anomalib.utils.cv import connected_components_cpu, connected_components_gpu
 
 
 class PRO(Metric):
@@ -69,44 +68,3 @@ def pro_score(predictions: Tensor, comps: Tensor, threshold: float = 0.5) -> Ten
         return torch.Tensor([1.0])
     pro = recall(preds.flatten(), comps.flatten(), num_classes=n_comps, average="macro", ignore_index=0)
     return pro
-
-
-def connected_components_gpu(binary_input: Tensor, num_iterations: int = 1000) -> Tensor:
-    """Perform connected component labeling on GPU and remap the labels from 0 to N.
-
-    Args:
-        binary_input (Tensor): Binary input data from which we want to extract connected components (Bx1xHxW)
-        num_iterations (int): Number of iterations used in the connected component computation.
-
-    Returns:
-        Tensor: Components labeled from 0 to N.
-    """
-    components = connected_components(binary_input, num_iterations=num_iterations)
-
-    # remap component values from 0 to N
-    labels = components.unique()
-    for new_label, old_label in enumerate(labels):
-        components[components == old_label] = new_label
-
-    return components.int()
-
-
-def connected_components_cpu(image: Tensor) -> Tensor:
-    """Connected component labeling on CPU.
-
-    Args:
-        image (Tensor): Binary input data from which we want to extract connected components (Bx1xHxW)
-
-    Returns:
-        Tensor: Components labeled from 0 to N.
-    """
-    components = torch.zeros_like(image)
-    label_idx = 1
-    for i, mask in enumerate(image):
-        mask = mask.squeeze().numpy().astype(np.uint8)
-        _, comps = cv2.connectedComponents(mask)
-        # remap component values to make sure every component has a unique value when outputs are concatenated
-        for label in np.unique(comps)[1:]:
-            components[i, 0, ...][np.where(comps == label)] = label_idx
-            label_idx += 1
-    return components.int()


### PR DESCRIPTION
# Description

This PR adds the detection task type. This is mainly to support region-based models that produce bounding box predictions instead of / in addition to anomaly maps.

## Changes
### Major
- Adds conversion utilities between masks and bounding boxes. This allows automatic generation of ground truth boxes for detection models. These utilities are also used to generate bounding box predictions when the model is of the segmentation type.
- The detection task uses the thresholding and evaluation mechanisms from the segmentation task under the hood. This is achieved by converting the bounding boxes to segmentation masks or anomaly maps before evaluating the metrics.
- Visualization functionality was added. This means that the predictions of any model capable of localization (segmentation or detection) can be visualized as detection predictions. For example, the following image was generated by passing `detection` as task type for a padim model training on MVTec bottle dataset:

![002](https://user-images.githubusercontent.com/26067904/203837192-a2392d63-f911-4b0a-9a59-e76d0280ded9.png)

### Minor
- Using enum instead of string to configure task type.
- A new `collate_fn` function had to be implemented to allow collating the ground truth bounding boxes across batches.

## Known issues
- No test cases (WIP)
- No inference support

## Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
