### PR TITLE
Fix zero seed

### DIFF
--- a/anomalib/config/config.py
+++ b/anomalib/config/config.py
@@ -142,11 +142,12 @@ def get_configurable_parameters(
     # keep track of the original config file because it will be modified
     config_original: DictConfig = config.copy()
 
+    # if the seed value is 0, notify a user that the behavior of the seed value zero has been changed.
     if config.project.get("seed") == 0:
         warn(
             "The seed value is now fixed to 0. "
-            "Up to v0.3.7, the seed value was randomized when the seed value was set to 0. "
-            "If you want to use the randomized seed values, please select the seed value of `None` "
+            "Up to v0.3.7, the seed was not fixed when the seed value was set to 0. "
+            "If you want to use the random seed, please select `None` for the seed value "
             "(`null` in the YAML file) or remove the `seed` key from the YAML file."
         )
 

--- a/anomalib/config/config.py
+++ b/anomalib/config/config.py
@@ -142,6 +142,14 @@ def get_configurable_parameters(
     # keep track of the original config file because it will be modified
     config_original: DictConfig = config.copy()
 
+    if config.project.get("seed") == 0:
+        warn(
+            "The seed value is now fixed to 0. "
+            "Up to v0.3.7, the seed value was randomized when the seed value was set to 0. "
+            "If you want to use the randomized seed values, please select the seed value of `None` "
+            "(`null` in the YAML file) or remove the `seed` key from the YAML file."
+        )
+
     # Dataset Configs
     if "format" not in config.dataset.keys():
         config.dataset.format = "mvtec"

--- a/tools/hpo/sweep.py
+++ b/tools/hpo/sweep.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
     model_config = get_configurable_parameters(model_name=args.model, config_path=args.model_config)
     hpo_config = OmegaConf.load(args.sweep_config)
 
-    if model_config.project.seed != 0:
+    if model_config.project.get("seed") is not None:
         seed_everything(model_config.project.seed)
 
     # check hpo config structure to see whether it adheres to comet or wandb format

--- a/tools/train.py
+++ b/tools/train.py
@@ -47,7 +47,7 @@ def train():
         warnings.filterwarnings("ignore")
 
     config = get_configurable_parameters(model_name=args.model, config_path=args.config)
-    if config.project.seed:
+    if config.project.get("seed") is not None:
         seed_everything(config.project.seed)
 
     datamodule = get_datamodule(config)


### PR DESCRIPTION
# Description

- This pull request changes the behavior when the random number seed is set to 0.
- In the current implementation, when the `config.project.seed` is set to 0, the seed value is not fixed to zero but randomized. After merging this pull request, when the `config.project.seed` is set to 0, the seed value is set to 0.
- A seed can be randomized by either removing the `seed` key from the YAML file or using `None` as the seed value (`null` in the YAML file).
- A warning message is generated when the seed value of 0 is used.
- Fixes #763.

It would be great to get feedback on my warning message because I am not a native English speaker.

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
