### PR TITLE
Allow setting manual threshold in PL inference

### DIFF
--- a/anomalib/utils/callbacks/__init__.py
+++ b/anomalib/utils/callbacks/__init__.py
@@ -69,6 +69,10 @@ def get_callbacks(config: Union[ListConfig, DictConfig]) -> List[Callback]:
 
     callbacks.extend([checkpoint, TimerCallback()])
 
+    if "resume_from_checkpoint" in config.trainer.keys() and config.trainer.resume_from_checkpoint is not None:
+        load_model = LoadModelCallback(config.trainer.resume_from_checkpoint)
+        callbacks.append(load_model)
+
     # Add post-processing configurations to AnomalyModule.
     image_threshold = (
         config.metrics.threshold.manual_image if "manual_image" in config.metrics.threshold.keys() else None
@@ -90,10 +94,6 @@ def get_callbacks(config: Union[ListConfig, DictConfig]) -> List[Callback]:
         config.metrics.get("pixel", None),
     )
     callbacks.append(metrics_callback)
-
-    if "resume_from_checkpoint" in config.trainer.keys() and config.trainer.resume_from_checkpoint is not None:
-        load_model = LoadModelCallback(config.trainer.resume_from_checkpoint)
-        callbacks.append(load_model)
 
     if "normalization_method" in config.model.keys() and not config.model.normalization_method == "none":
         if config.model.normalization_method == "cdf":

--- a/anomalib/utils/callbacks/model_loader.py
+++ b/anomalib/utils/callbacks/model_loader.py
@@ -4,9 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+from typing import Optional
 
 import torch
-from pytorch_lightning import Callback
+from pytorch_lightning import Callback, Trainer
 from pytorch_lightning.utilities.cli import CALLBACK_REGISTRY
 
 from anomalib.models.components import AnomalyModule
@@ -21,15 +22,8 @@ class LoadModelCallback(Callback):
     def __init__(self, weights_path):
         self.weights_path = weights_path
 
-    def on_test_start(self, _trainer, pl_module: AnomalyModule) -> None:  # pylint: disable=W0613
-        """Call when the test begins.
-
-        Loads the model weights from ``weights_path`` into the PyTorch module.
-        """
-        logger.info("Loading the model from %s", self.weights_path)
-        pl_module.load_state_dict(torch.load(self.weights_path, map_location=pl_module.device)["state_dict"])
-
-    def on_predict_start(self, _trainer, pl_module: AnomalyModule) -> None:
+    # pylint: disable=unused-argument
+    def setup(self, trainer: Trainer, pl_module: AnomalyModule, stage: Optional[str] = None) -> None:
         """Call when inference begins.
 
         Loads the model weights from ``weights_path`` into the PyTorch module.

--- a/docs/source/tutorials/inference.rst
+++ b/docs/source/tutorials/inference.rst
@@ -9,6 +9,10 @@ PyTorch (Lightning) Inference
 =============================
 The entrypoint script in ``tools/inference/lightning.py`` can be used to run inference with a trained PyTorch model. The script runs inference by loading a previously trained model into a PyTorch Lightning trainer and running the ``predict sequence``. The entrypoint script has several command line arguments that can be used to configure inference:
 
+Like the other PyTorch Lightning entrypoints, the inference script reads the model configuration from a config file. It is generally advisible to use the same config file that was used when training the model, although some inference-related paremeter values may be changed to accommodate your needs. Some settings that you might want to change before inference are the batch size, transform config and number of workers for the dataloader.
+
+It is also possible to run inference with a custom anomaly score threshold that differs from the threshold used/computed during training. To change the threshold for inference, simply set the `metrics.threshold.method` to `manual` and specify the custom threshold values in `metrics.threshold.manual_image` and `metrics.threshold.manual_pixel`.
+
 +---------------------+----------+---------------------------------------------------------------------------------+
 |      Parameter      | Required |                                   Description                                   |
 +=====================+==========+=================================================================================+
@@ -22,7 +26,7 @@ The entrypoint script in ``tools/inference/lightning.py`` can be used to run inf
 +---------------------+----------+---------------------------------------------------------------------------------+
 | visualization_mode  | False    | Determines how the inference results are visualized. Options: "full", "simple". |
 +---------------------+----------+---------------------------------------------------------------------------------+
-| disable_show_images | False    | When this flag is passed, visualizations will not be shown on the screen.       |
+| show                | False    | When true, the visualized inference results will be displayed on the screen.    |
 +---------------------+----------+---------------------------------------------------------------------------------+
 
 To run inference, call the script from the command line with the with the following parameters, e.g.:

--- a/docs/source/tutorials/inference.rst
+++ b/docs/source/tutorials/inference.rst
@@ -11,7 +11,7 @@ The entrypoint script in ``tools/inference/lightning.py`` can be used to run inf
 
 Like the other PyTorch Lightning entrypoints, the inference script reads the model configuration from a config file. It is generally advisible to use the same config file that was used when training the model, although some inference-related paremeter values may be changed to accommodate your needs. Some settings that you might want to change before inference are the batch size, transform config and number of workers for the dataloader.
 
-It is also possible to run inference with a custom anomaly score threshold that differs from the threshold used/computed during training. To change the threshold for inference, simply set the `metrics.threshold.method` to `manual` and specify the custom threshold values in `metrics.threshold.manual_image` and `metrics.threshold.manual_pixel`.
+It is also possible to run inference with a custom anomaly score threshold that differs from the threshold used/computed during training. To change the threshold for inference, simply set the ``metrics.threshold.method`` to ``manual`` and specify the custom threshold values in ``metrics.threshold.manual_image`` and ``metrics.threshold.manual_pixel``.
 
 +---------------------+----------+---------------------------------------------------------------------------------+
 |      Parameter      | Required |                                   Description                                   |


### PR DESCRIPTION
# Description

- This PR makes a few small changes which allows users to set a manual threshold when running lightning inference, even after the model has been trained with adaptive thresholding enabled. To use the manual threshold, the user can simply set the thresholding method to `manual` in the config, and specify the image and pixel-level thresholds. These values will then overwrite the adaptive threshold values which are loaded from the model weights.

- The model loading functionality in LoadModelCallback was moved from `on_test_start` and `on_predict_start`, which removes duplication and is more in line with the intended use of `setup`.
- By adding the model loader callback before the post-processing configuration callbacks, the threshold value is first loaded from the model file. Then, when setup is called in post-processing configuration callback, the thresholds are overwritten by the manual values specified by the user in the `config.yaml`.

Based on my experimentation I could not find any side effects of these changes, but it would be good if the reviewers could double check this on their side.

Related discussions: https://github.com/openvinotoolkit/anomalib/discussions/578, https://github.com/openvinotoolkit/anomalib/discussions/767

## Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
