### PR TITLE
Revert "Optimized inference with onnx for patchcore. (#652)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fix PatchCore performance deterioration by reverting changes to Average Pooling layer (<https://github.com/openvinotoolkit/anomalib/pull/791>)
 - Fix zero seed (<https://github.com/openvinotoolkit/anomalib/pull/766>)
 - Fix #699 (<https://github.com/openvinotoolkit/anomalib/pull/700>)
 - 🐞 Fix folder dataset for classification tasks (<https://github.com/openvinotoolkit/anomalib/pull/708>)

--- a/anomalib/models/patchcore/torch_model.py
+++ b/anomalib/models/patchcore/torch_model.py
@@ -38,7 +38,7 @@ class PatchcoreModel(DynamicBufferModule, nn.Module):
         self.num_neighbors = num_neighbors
 
         self.feature_extractor = FeatureExtractor(backbone=self.backbone, pre_trained=pre_trained, layers=self.layers)
-        self.feature_pooler = torch.nn.AvgPool2d(3, 1, 1, count_include_pad=False)
+        self.feature_pooler = torch.nn.AvgPool2d(3, 1, 1)
         self.anomaly_map_generator = AnomalyMapGenerator(input_size=input_size)
 
         self.register_buffer("memory_bank", Tensor())


### PR DESCRIPTION
This reverts commit e965c8a69259eb5b91c876068233f9b9a65ecf5f.

# Description

- Reverts a recent change to the Average Pooling layer of PatchCore model which caused the performance deterioration reported by some users in https://github.com/openvinotoolkit/anomalib/issues/715

- Fixes https://github.com/openvinotoolkit/anomalib/issues/715

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
