### PR TITLE
Deprecate OptimalF1 metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - 📊 Update DFM results (<https://github.com/openvinotoolkit/anomalib/pull/674>)
 - Optimize anomaly score calculation for PatchCore (<https://github.com/openvinotoolkit/anomalib/pull/633>)
 
+### Deprecated
+
+- Deprecate OptimalF1 metric in favor of AnomalyScoreThreshold and F1Score (<https://github.com/openvinotoolkit/anomalib/pull/796>)
+
 ### Fixed
 
 - Fix PatchCore performance deterioration by reverting changes to Average Pooling layer (<https://github.com/openvinotoolkit/anomalib/pull/791>)

--- a/anomalib/utils/metrics/optimal_f1.py
+++ b/anomalib/utils/metrics/optimal_f1.py
@@ -3,6 +3,8 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
+
 import torch
 from torchmetrics import Metric, PrecisionRecallCurve
 
@@ -17,6 +19,13 @@ class OptimalF1(Metric):
     full_state_update: bool = False
 
     def __init__(self, num_classes: int, **kwargs):
+        warnings.warn(
+            DeprecationWarning(
+                "OptimalF1 metric is deprecated and will be removed in a future release. The optimal F1 score for "
+                "Anomalib predictions can be obtained by computing the adaptive threshold with the "
+                "AnomalyScoreThreshold metric and setting the computed threshold value in TorchMetrics F1Score metric."
+            )
+        )
         super().__init__(**kwargs)
 
         self.precision_recall_curve = PrecisionRecallCurve(num_classes=num_classes)


### PR DESCRIPTION
# Description

- Quick PR to deprecate OptimalF1 metric, which has not been used in recent releases since we switched to a dedicated threshold metric class.

## Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
