### PR TITLE
Bugfixes for Datamodules feature branch

### DIFF
--- a/anomalib/config/config.py
+++ b/anomalib/config/config.py
@@ -225,7 +225,7 @@ def get_configurable_parameters(
             config.dataset.mask_dir = config.dataset.mask
         if "path" in config.dataset:
             warn(DeprecationWarning("path will be deprecated in favor of root in config.dataset in a future release."))
-            config.dataset.mask_dir = config.dataset.mask
+            config.dataset.root = config.dataset.path
 
     # add category subfolder if needed
     if config.dataset.format.lower() in ("btech", "mvtec"):

--- a/anomalib/data/folder.py
+++ b/anomalib/data/folder.py
@@ -136,7 +136,7 @@ def make_folder_dataset(
         filenames += filename
         labels += label
 
-    samples = DataFrame({"image_path": filenames, "label": labels})
+    samples = DataFrame({"image_path": filenames, "label": labels, "mask_path": ""})
 
     # Create label index for normal (0) and abnormal (1) images.
     samples.loc[(samples.label == "normal") | (samples.label == "normal_test"), "label_index"] = 0
@@ -146,7 +146,6 @@ def make_folder_dataset(
     # If a path to mask is provided, add it to the sample dataframe.
     if mask_dir is not None:
         mask_dir = _check_and_convert_path(mask_dir)
-        samples["mask_path"] = ""
         for index, row in samples.iterrows():
             if row.label_index == 1:
                 rel_image_path = row.image_path.relative_to(abnormal_dir)


### PR DESCRIPTION
# Description

- This PR fixes two bugs on the datamodules branch that were discovered after manual testing. Both are related to the parsing of the Folder dataset format.

- The dataset would throw an error when mask_dir was left empty in classification mode. This was solved by setting an empty mask_path when the samples dataframe is created.
- The deprecation of `dataset.path` in favor of `dataset.root` was not handled correctly (the config update was copied too quickly from the `mask` vs `mask_dir` deprecation).

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
