### PR TITLE
Improve handling of `test_split_mode='none'` and `val_split_mode='none'`

### DIFF
--- a/anomalib/config/config.py
+++ b/anomalib/config/config.py
@@ -183,7 +183,7 @@ def update_datasets_config(config: Union[DictConfig, ListConfig]) -> Union[DictC
         )
         config.dataset.normal_split_ratio = config.dataset.split_ratio
 
-    if config.dataset.test_split_mode == TestSplitMode.NONE and config.dataset.val_split_mode in [
+    if config.dataset.get("test_split_mode") == TestSplitMode.NONE and config.dataset.get("val_split_mode") in [
         ValSplitMode.SAME_AS_TEST,
         ValSplitMode.FROM_TEST,
     ]:
@@ -193,7 +193,7 @@ def update_datasets_config(config: Union[DictConfig, ListConfig]) -> Union[DictC
         )
         config.dataset.val_split_mode = ValSplitMode.NONE
 
-    if config.dataset.val_split_mode == ValSplitMode.NONE and config.trainer.limit_val_batches != 0.0:
+    if config.dataset.get("val_split_mode") == ValSplitMode.NONE and config.trainer.limit_val_batches != 0.0:
         warn("Running without validation set. Setting trainer.limit_val_batches to 0.")
         config.trainer.limit_val_batches = 0.0
     return config

--- a/anomalib/config/config.py
+++ b/anomalib/config/config.py
@@ -178,10 +178,10 @@ def update_datasets_config(config: Union[DictConfig, ListConfig]) -> Union[DictC
         warn(
             DeprecationWarning(
                 "The 'split_ratio' parameter is deprecated and will be removed in a future release. Please use "
-                "'normal_split_ratio' instead."
+                "'test_split_ratio' instead."
             )
         )
-        config.dataset.normal_split_ratio = config.dataset.split_ratio
+        config.dataset.test_split_ratio = config.dataset.split_ratio
 
     if config.dataset.get("test_split_mode") == TestSplitMode.NONE and config.dataset.get("val_split_mode") in [
         ValSplitMode.SAME_AS_TEST,

--- a/anomalib/config/config.py
+++ b/anomalib/config/config.py
@@ -14,6 +14,8 @@ from warnings import warn
 
 from omegaconf import DictConfig, ListConfig, OmegaConf
 
+from anomalib.data.utils import TestSplitMode, ValSplitMode
+
 
 def _get_now_str(timestamp: float) -> str:
     """Standard format for datetimes is defined here."""
@@ -180,6 +182,20 @@ def update_datasets_config(config: Union[DictConfig, ListConfig]) -> Union[DictC
             )
         )
         config.dataset.normal_split_ratio = config.dataset.split_ratio
+
+    if config.dataset.test_split_mode == TestSplitMode.NONE and config.dataset.val_split_mode in [
+        ValSplitMode.SAME_AS_TEST,
+        ValSplitMode.FROM_TEST,
+    ]:
+        warn(
+            f"val_split_mode {config.dataset.val_split_mode} not allowed for test_split_mode = 'none'. "
+            "Setting val_split_mode to 'none'."
+        )
+        config.dataset.val_split_mode = ValSplitMode.NONE
+
+    if config.dataset.val_split_mode == ValSplitMode.NONE and config.trainer.limit_val_batches != 0.0:
+        warn("Running without validation set. Setting trainer.limit_val_batches to 0.")
+        config.trainer.limit_val_batches = 0.0
     return config
 
 

--- a/anomalib/data/base/datamodule.py
+++ b/anomalib/data/base/datamodule.py
@@ -120,8 +120,9 @@ class AnomalibDataModule(LightningDataModule, ABC):
         if self.test_data.has_normal:
             # split the test data into normal and anomalous so these can be processed separately
             normal_test_data, self.test_data = split_by_label(self.test_data)
-        else:
-            # when the user did not provide any normal images for testing, we sample some from the training set
+        elif self.test_split_mode != TestSplitMode.NONE:
+            # when the user did not provide any normal images for testing, we sample some from the training set,
+            # except when the user explicitly requested no test splitting.
             logger.info(
                 "No normal test images found. Sampling from training set using a split ratio of %d",
                 self.test_split_ratio,
@@ -132,7 +133,7 @@ class AnomalibDataModule(LightningDataModule, ABC):
             self.test_data += normal_test_data
         elif self.test_split_mode == TestSplitMode.SYNTHETIC:
             self.test_data = SyntheticAnomalyDataset.from_dataset(normal_test_data)
-        else:
+        elif self.test_split_mode != TestSplitMode.NONE:
             raise ValueError(f"Unsupported Test Split Mode: {self.test_split_mode}")
 
     def _create_val_split(self):

--- a/tools/train.py
+++ b/tools/train.py
@@ -16,6 +16,7 @@ from pytorch_lightning import Trainer, seed_everything
 
 from anomalib.config import get_configurable_parameters
 from anomalib.data import get_datamodule
+from anomalib.data.utils import TestSplitMode
 from anomalib.models import get_model
 from anomalib.utils.callbacks import LoadModelCallback, get_callbacks
 from anomalib.utils.loggers import configure_logger, get_experiment_logger
@@ -63,11 +64,11 @@ def train():
     load_model_callback = LoadModelCallback(weights_path=trainer.checkpoint_callback.best_model_path)
     trainer.callbacks.insert(0, load_model_callback)
 
-    if len(datamodule.test_data) != 0:
+    if config.dataset.test_split_mode == TestSplitMode.NONE:
+        logger.info("No test set provided. Skipping test stage.")
+    else:
         logger.info("Testing the model.")
         trainer.test(model=model, datamodule=datamodule)
-    else:
-        logger.info("No anomalous images found in dataset. Skipping test stage.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description

Fix for another problem that came up during manual testing of the datamodules branch. The `none` option for `test_split_mode` and `val_split_mode` was not handled properly.

- Prevents sampling normal images from train set to test set when the default test set does not contain normals and `test_split_mode` is `none`.
- Ensures that `limit_val_batches` is set to 0.0 when `val_split_mode` is `none`, to prevent the trainer from trying to run validation on a non-existing validation set.
- `from_test` and `same_as_test` not allowed for `val_split_mode` when test_split_mode is `none` to prevent sampling from non-existing test set.
- Using `test_split_mode` to determine if trainer should test after training.


## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
