### PR TITLE
[Datamodules] Fix bug in bbox score to image score conversion

### DIFF
--- a/anomalib/models/components/base/anomaly_module.py
+++ b/anomalib/models/components/base/anomaly_module.py
@@ -165,7 +165,10 @@ class AnomalyModule(pl.LightningModule, ABC):
             )
         elif "pred_scores" not in outputs and "boxes_scores" in outputs:
             # infer image score from bbox confidence scores
-            outputs["pred_scores"] = torch.stack([scores.max() for scores in outputs["boxes_scores"]])
+            outputs["pred_scores"] = torch.zeros_like(outputs["label"]).float()
+            for idx, (boxes, scores) in enumerate(zip(outputs["pred_boxes"], outputs["boxes_scores"])):
+                if boxes.numel():
+                    outputs["pred_scores"][idx] = scores.max().item()
 
         if "pred_boxes" in outputs and "anomaly_maps" not in outputs:
             # create anomaly maps from bbox predictions for thresholding and evaluation


### PR DESCRIPTION
# Description

Another fix for the datamodules feature branch. This one is related to the detection task. Previously the code responsible for obtaining an image score from the bbox scores for a given image was broken. The code assumed that bbox detections were always present in each image. An empty list of bboxes would lead to an error. This PR fixes the issue by setting the score to 0 when no bbox detections are present in the image.

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
