### PR TITLE
[Detection] Compute box score when generating boxes from masks

### DIFF
--- a/anomalib/data/base/dataset.py
+++ b/anomalib/data/base/dataset.py
@@ -134,7 +134,8 @@ class AnomalibDataset(Dataset, ABC):
 
             if self.task == TaskType.DETECTION:
                 # create boxes from masks for detection task
-                item["boxes"] = masks_to_boxes(item["mask"])[0]
+                boxes, _ = masks_to_boxes(item["mask"])
+                item["boxes"] = boxes[0]
         else:
             raise ValueError(f"Unknown task type: {self.task}")
 

--- a/anomalib/data/base/video.py
+++ b/anomalib/data/base/video.py
@@ -81,7 +81,7 @@ class AnomalibVideoDataset(AnomalibDataset, ABC):
             item["mask"] = torch.stack([item["mask"] for item in processed_frames]).squeeze(0)
             item["label"] = Tensor([1 in frame for frame in mask]).int().squeeze(0)
             if self.task == TaskType.DETECTION:
-                item["boxes"] = masks_to_boxes(item["mask"])
+                item["boxes"], _ = masks_to_boxes(item["mask"])
                 item["boxes"] = item["boxes"][0] if len(item["boxes"]) == 1 else item["boxes"]
         else:
             item["image"] = torch.stack(

--- a/anomalib/data/utils/boxes.py
+++ b/anomalib/data/utils/boxes.py
@@ -43,10 +43,7 @@ def masks_to_boxes(masks: Tensor, anomaly_maps: Optional[Tensor] = None) -> Tupl
         for label in labels[labels != 0]:
             y_loc, x_loc = torch.where(im_comps == label)
             # add box
-            box = Tensor([torch.min(x_loc), torch.min(y_loc), torch.max(x_loc), torch.max(y_loc)])
-            if box[1] >= box[3] or box[0] >= box[2]:  # skip boxes with a width or height of 1 pixel
-                continue
-            im_boxes.append(box)
+            im_boxes.append(Tensor([torch.min(x_loc), torch.min(y_loc), torch.max(x_loc), torch.max(y_loc)]))
             if anomaly_maps is not None:
                 im_scores.append(torch.max(anomaly_maps[im_idx, y_loc, x_loc]))
         batch_boxes.append(torch.stack(im_boxes) if len(im_boxes) > 0 else torch.empty((0, 4)))

--- a/anomalib/data/utils/boxes.py
+++ b/anomalib/data/utils/boxes.py
@@ -25,7 +25,8 @@ def masks_to_boxes(masks: Tensor, anomaly_maps: Optional[Tensor] = None) -> Tupl
         List[Tensor]: A list of length B where each element is a tensor of length (N) containing an anomaly score for
             each of the converted boxes.
     """
-    masks = masks.view((-1, 1) + masks.shape[-2:]).float()  # reshape to (B, 1, H, W)
+    height, width = masks.shape[-2:]
+    masks = masks.view((-1, 1, height, width)).float()  # reshape to (B, 1, H, W) and cast to float
     if anomaly_maps is not None:
         anomaly_maps = anomaly_maps.view((-1,) + masks.shape[-2:])
 

--- a/anomalib/data/utils/boxes.py
+++ b/anomalib/data/utils/boxes.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import torch
 from torch import Tensor
@@ -11,18 +11,23 @@ from torch import Tensor
 from anomalib.utils.cv import connected_components_cpu, connected_components_gpu
 
 
-def masks_to_boxes(masks: Tensor) -> List[Tensor]:
+def masks_to_boxes(masks: Tensor, anomaly_maps: Optional[Tensor] = None) -> Tuple[List[Tensor], List[Tensor]]:
     """Convert a batch of segmentation masks to bounding box coordinates.
 
     Args:
         masks (Tensor): Input tensor of shape (B, 1, H, W), (B, H, W) or (H, W)
+        anomaly_maps (Optional[Tensor], optional): Anomaly maps of shape (B, 1, H, W), (B, H, W) or (H, W) which are
+            used to determine an anomaly score for the converted bounding boxes.
 
     Returns:
         List[Tensor]: A list of length B where each element is a tensor of shape (N, 4) containing the bounding box
             coordinates of the objects in the masks in xyxy format.
+        List[Tensor]: A list of length B where each element is a tensor of length (N) containing an anomaly score for
+            each of the converted boxes.
     """
-    masks = masks.view((-1, 1) + masks.shape[-2:])  # reshape to (B, 1, H, W)
-    masks = masks.float()
+    masks = masks.view((-1, 1) + masks.shape[-2:]).float()  # reshape to (B, 1, H, W)
+    if anomaly_maps is not None:
+        anomaly_maps = anomaly_maps.view((-1,) + masks.shape[-2:])
 
     if masks.is_cuda:
         batch_comps = connected_components_gpu(masks).squeeze(1)
@@ -30,14 +35,22 @@ def masks_to_boxes(masks: Tensor) -> List[Tensor]:
         batch_comps = connected_components_cpu(masks).squeeze(1)
 
     batch_boxes = []
-    for im_comps in batch_comps:
+    batch_scores = []
+    for im_idx, im_comps in enumerate(batch_comps):
         labels = torch.unique(im_comps)
         im_boxes = []
+        im_scores = []
         for label in labels[labels != 0]:
             y_loc, x_loc = torch.where(im_comps == label)
+            # add box
             im_boxes.append(Tensor([torch.min(x_loc), torch.min(y_loc), torch.max(x_loc), torch.max(y_loc)]))
+            # add score
+            if anomaly_maps is not None:
+                im_scores.append(torch.max(anomaly_maps[im_idx, y_loc, x_loc]))
         batch_boxes.append(torch.stack(im_boxes) if len(im_boxes) > 0 else torch.empty((0, 4)))
-    return batch_boxes
+        batch_scores.append(torch.stack(im_scores) if len(im_scores) > 0 else torch.empty(0))
+
+    return batch_boxes, batch_scores
 
 
 def boxes_to_masks(boxes: List[Tensor], image_size: Tuple[int, int]) -> Tensor:

--- a/anomalib/data/utils/boxes.py
+++ b/anomalib/data/utils/boxes.py
@@ -43,8 +43,10 @@ def masks_to_boxes(masks: Tensor, anomaly_maps: Optional[Tensor] = None) -> Tupl
         for label in labels[labels != 0]:
             y_loc, x_loc = torch.where(im_comps == label)
             # add box
-            im_boxes.append(Tensor([torch.min(x_loc), torch.min(y_loc), torch.max(x_loc), torch.max(y_loc)]))
-            # add score
+            box = Tensor([torch.min(x_loc), torch.min(y_loc), torch.max(x_loc), torch.max(y_loc)])
+            if box[1] >= box[3] or box[0] >= box[2]:  # skip boxes with a width or height of 1 pixel
+                continue
+            im_boxes.append(box)
             if anomaly_maps is not None:
                 im_scores.append(torch.max(anomaly_maps[im_idx, y_loc, x_loc]))
         batch_boxes.append(torch.stack(im_boxes) if len(im_boxes) > 0 else torch.empty((0, 4)))

--- a/anomalib/deploy/inferencers/torch_inferencer.py
+++ b/anomalib/deploy/inferencers/torch_inferencer.py
@@ -208,7 +208,7 @@ class TorchInferencer(Inferencer):
                 pred_mask = cv2.resize(pred_mask, (image_width, image_height))
 
         if self.config.dataset.task == TaskType.DETECTION:
-            pred_boxes = masks_to_boxes(torch.from_numpy(pred_mask))[0].numpy()
+            pred_boxes = masks_to_boxes(torch.from_numpy(pred_mask))[0][0].numpy()
             box_labels = np.ones(pred_boxes.shape[0])
         else:
             pred_boxes = None

--- a/anomalib/models/components/base/anomaly_module.py
+++ b/anomalib/models/components/base/anomaly_module.py
@@ -85,10 +85,12 @@ class AnomalyModule(pl.LightningModule, ABC):
         if "anomaly_maps" in outputs.keys():
             outputs["pred_masks"] = outputs["anomaly_maps"] >= self.pixel_threshold.value
             if "pred_boxes" not in outputs.keys():
-                outputs["pred_boxes"] = masks_to_boxes(outputs["pred_masks"])
+                outputs["pred_boxes"], outputs["box_scores"] = masks_to_boxes(
+                    outputs["pred_masks"], outputs["anomaly_maps"]
+                )
                 outputs["box_labels"] = [torch.ones(boxes.shape[0]) for boxes in outputs["pred_boxes"]]
         # apply thresholding to boxes
-        if "box_scores" in outputs:
+        if "box_scores" in outputs and "box_labels" not in outputs:
             # apply threshold to assign normal/anomalous label to boxes
             is_anomalous = [scores > self.pixel_threshold.value for scores in outputs["box_scores"]]
             outputs["box_labels"] = [labels.int() for labels in is_anomalous]


### PR DESCRIPTION
# Description

Small PR that adds an anomaly score for bounding boxes generated from anomaly maps, which is needed for the OTX task.

- Extends `masks_to_boxes` to take anomaly maps as optional additional input, and compute an anomaly score for each bounding box as the max value of the anomaly map within the pixel region covered by the bounding box.
- Update the logic in `AnomalyModule`.

## Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
