### PR TITLE
fix mvtec download path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fix bug in MVTec dataset download (<https://github.com/openvinotoolkit/anomalib/pull/842>)
 - Add early stopping to CS-Flow model (<https://github.com/openvinotoolkit/anomalib/pull/817>)
 - Fix remote container by removing version pinning in Docker files (<https://github.com/openvinotoolkit/anomalib/pull/797>)
 - Fix PatchCore performance deterioration by reverting changes to Average Pooling layer (<https://github.com/openvinotoolkit/anomalib/pull/791>)

--- a/anomalib/data/mvtec.py
+++ b/anomalib/data/mvtec.py
@@ -49,7 +49,8 @@ IMG_EXTENSIONS = [".png", ".PNG"]
 
 DOWNLOAD_INFO = DownloadInfo(
     name="mvtec",
-    url="https://www.mydrive.ch/shares/38536/3830184030e49fe74747669442f0f282/download/420938113-1629952094",
+    url="https://www.mydrive.ch/shares/38536/3830184030e49fe74747669442f0f282/download/420938113-1629952094"
+    "/mvtec_anomaly_detection.tar.xz",
     hash="eefca59f2cede9c3fc5b6befbfec275e",
 )
 

--- a/anomalib/data/utils/download.py
+++ b/anomalib/data/utils/download.py
@@ -241,7 +241,7 @@ def download_and_extract(root: Path, info: DownloadInfo):
     if downloaded_file_path.suffix == ".zip":
         with ZipFile(downloaded_file_path, "r") as zip_file:
             zip_file.extractall(root)
-    elif downloaded_file_path.suffix in [".tar", ".gz"]:
+    elif downloaded_file_path.suffix in [".tar", ".gz", ".xz"]:
         with tarfile.open(downloaded_file_path) as tar_file:
             tar_file.extractall(root)
     else:


### PR DESCRIPTION
# Description

- Fixes bug in MVTec dataset download caused by file name missing from the download url.

- Fixes https://github.com/openvinotoolkit/anomalib/issues/835

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
