### PR TITLE
Speed up datamodule tests

### DIFF
--- a/tests/pre_merge/datasets/test_datamodule.py
+++ b/tests/pre_merge/datasets/test_datamodule.py
@@ -305,8 +305,7 @@ class TestConfigToDataModule:
 
 
 class TestSubsetSplitting:
-    @pytest.mark.parametrize("dataset", ["folder", "mvtec", "btech"])
-    # @pytest.mark.parametrize("dataset", ["folder"])
+    @pytest.mark.parametrize("dataset", ["folder"])
     @pytest.mark.parametrize("test_split_mode", ("from_dir", "synthetic"))
     @pytest.mark.parametrize("val_split_mode", ("from_test", "synthetic"))
     def test_non_overlapping_splits(self, make_data_module, dataset, test_split_mode, val_split_mode):
@@ -318,8 +317,7 @@ class TestSubsetSplitting:
         assert len(set(train_samples.image_path).intersection(set(test_samples.image_path))) == 0
         assert len(set(val_samples.image_path).intersection(set(test_samples.image_path))) == 0
 
-    @pytest.mark.parametrize("dataset", ["folder", "mvtec", "btech"])
-    # @pytest.mark.parametrize("dataset", ["folder"])
+    @pytest.mark.parametrize("dataset", ["folder"])
     @pytest.mark.parametrize("test_split_mode", ("from_dir", "synthetic"))
     def test_equal_splits(self, make_data_module, dataset, test_split_mode):
         """Tests if test and and val splits are equal and non-overlapping with train."""


### PR DESCRIPTION
# Description

- This PR speeds up the data module tests by only testing the subset splitting on Folder dataset. This does not reduce the coverage, because the subset splitting is handled by the base data module. So testing with multiple dataset formats was redundant.
- speeds up `test_datamodule.py` from ~6.5 min to ~40 sec.

## Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
