### PR TITLE
Remove deprecated usage of np.bool

### DIFF
--- a/anomalib/post_processing/visualizer.py
+++ b/anomalib/post_processing/visualizer.py
@@ -55,8 +55,8 @@ class ImageResult:
             self.gt_mask *= 255
         if self.pred_boxes is not None:
             assert self.box_labels is not None, "Box labels must be provided when box locations are provided."
-            self.normal_boxes = self.pred_boxes[~self.box_labels.astype(np.bool)]
-            self.anomalous_boxes = self.pred_boxes[self.box_labels.astype(np.bool)]
+            self.normal_boxes = self.pred_boxes[~self.box_labels.astype(bool)]
+            self.anomalous_boxes = self.pred_boxes[self.box_labels.astype(bool)]
 
 
 class Visualizer:


### PR DESCRIPTION
Crashes if using version of numpy > 1.23.1 (tested on 1.24.1)

# Description

- Provide a summary of the modification as well as the issue that has been resolved. List any dependencies that this modification necessitates.

- Fixes # (issue)

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
