### PR TITLE
Link dataset path locally in workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,9 @@ on:
       - ".github/**" # Ignore changes towards the .github directory
   workflow_dispatch: # run on request (no need for PR)
 
+permissions:
+  pull-requests: write
+
 jobs:
   Build-and-Publish-Documentation:
     runs-on: [docs]
@@ -16,7 +19,7 @@ jobs:
       - name: Install requirements
         run: |
           pip install .[full]
-      - name: Link dataset path to local directory
+      - name: Link dataset path to local directory as nbsphinx runs the notebook
         run: ln -s $ANOMALIB_DATASET_PATH ./datasets
       - name: Build and Commit Docs
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,8 @@ jobs:
       - name: Install requirements
         run: |
           pip install .[full]
+      - name: Link dataset path to local directory
+        run: ln -s $ANOMALIB_DATASET_PATH ./datasets
       - name: Build and Commit Docs
         run: |
           cd docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch: # run on request (no need for PR)
 
 permissions:
-  pull-requests: write
+  contents: write
 
 jobs:
   Build-and-Publish-Documentation:


### PR DESCRIPTION
# Description

- Since nbsphinx runs the notebooks, it uses the local dataset path. This is because only the tests get path either locally or from the environment variable. This PR links the dataset path from the environment variable to the local folder.

# Runs

- This works: https://github.com/openvinotoolkit/anomalib/actions/runs/4042706269/jobs/6950734804. The issue was that we have disabled write permissions so this workflow explicitly enables it for this job.