### PR TITLE
Changed the type of root in data modules

### DIFF
--- a/anomalib/data/avenue.py
+++ b/anomalib/data/avenue.py
@@ -168,7 +168,7 @@ class Avenue(AnomalibVideoDataModule):
     """Avenue DataModule class.
 
     Args:
-        root (str): Path to the root of the dataset
+        root (Path | str): Path to the root of the dataset
         gt_dir (str): Path to the ground truth files
         clip_length_in_frames (int, optional): Number of video frames in each clip.
         frames_between_clips (int, optional): Number of frames between each consecutive video clip.
@@ -194,7 +194,7 @@ class Avenue(AnomalibVideoDataModule):
 
     def __init__(
         self,
-        root: str,
+        root: Path | str,
         gt_dir: str,
         clip_length_in_frames: int = 1,
         frames_between_clips: int = 1,
@@ -220,7 +220,7 @@ class Avenue(AnomalibVideoDataModule):
             seed=seed,
         )
 
-        self.root = Path(root)
+        self.root = Path(root) if isinstance(root, str) else root
         self.gt_dir = Path(gt_dir)
 
         transform_train = get_transforms(

--- a/anomalib/data/avenue.py
+++ b/anomalib/data/avenue.py
@@ -135,7 +135,7 @@ class AvenueDataset(AnomalibVideoDataset):
     Args:
         task (TaskType): Task type, 'classification', 'detection' or 'segmentation'
         root (Path | str): Path to the root of the dataset
-        gt_dir (str): Path to the ground truth files
+        gt_dir (Path | str): Path to the ground truth files
         transform (A.Compose): Albumentations Compose object describing the transforms that are applied to the inputs.
         split (Split): Split of the dataset, usually Split.TRAIN or Split.TEST
         clip_length_in_frames (int, optional): Number of video frames in each clip.
@@ -146,7 +146,7 @@ class AvenueDataset(AnomalibVideoDataset):
         self,
         task: TaskType,
         root: Path | str,
-        gt_dir: str,
+        gt_dir: Path | str,
         transform: A.Compose,
         split: Split,
         clip_length_in_frames: int = 1,
@@ -155,7 +155,7 @@ class AvenueDataset(AnomalibVideoDataset):
         super().__init__(task, transform, clip_length_in_frames, frames_between_clips)
 
         self.root = root if isinstance(root, Path) else Path(root)
-        self.gt_dir = Path(gt_dir)
+        self.gt_dir = gt_dir if isinstance(gt_dir, Path) else Path(gt_dir)
         self.split = split
         self.indexer_cls: Callable = AvenueClipsIndexer
 
@@ -169,7 +169,7 @@ class Avenue(AnomalibVideoDataModule):
 
     Args:
         root (Path | str): Path to the root of the dataset
-        gt_dir (str): Path to the ground truth files
+        gt_dir (Path | str): Path to the ground truth files
         clip_length_in_frames (int, optional): Number of video frames in each clip.
         frames_between_clips (int, optional): Number of frames between each consecutive video clip.
         task TaskType): Task type, 'classification', 'detection' or 'segmentation'
@@ -195,7 +195,7 @@ class Avenue(AnomalibVideoDataModule):
     def __init__(
         self,
         root: Path | str,
-        gt_dir: str,
+        gt_dir: Path | str,
         clip_length_in_frames: int = 1,
         frames_between_clips: int = 1,
         task: TaskType = TaskType.SEGMENTATION,
@@ -221,7 +221,7 @@ class Avenue(AnomalibVideoDataModule):
         )
 
         self.root = Path(root) if isinstance(root, str) else root
-        self.gt_dir = Path(gt_dir)
+        self.gt_dir = Path(gt_dir) if isinstance(gt_dir, str) else gt_dir
 
         transform_train = get_transforms(
             config=transform_config_train,

--- a/anomalib/data/avenue.py
+++ b/anomalib/data/avenue.py
@@ -220,8 +220,8 @@ class Avenue(AnomalibVideoDataModule):
             seed=seed,
         )
 
-        self.root = Path(root) if isinstance(root, str) else root
-        self.gt_dir = Path(gt_dir) if isinstance(gt_dir, str) else gt_dir
+        self.root = Path(root)
+        self.gt_dir = Path(gt_dir)
 
         transform_train = get_transforms(
             config=transform_config_train,

--- a/anomalib/data/base/dataset.py
+++ b/anomalib/data/base/dataset.py
@@ -45,7 +45,7 @@ class AnomalibDataset(Dataset, ABC):
         super().__init__()
         self.task = task
         self.transform = transform
-        self._samples: DataFrame = None
+        self._samples: DataFrame
 
     def __len__(self) -> int:
         """Get length of the dataset."""

--- a/anomalib/data/base/dataset.py
+++ b/anomalib/data/base/dataset.py
@@ -45,7 +45,7 @@ class AnomalibDataset(Dataset, ABC):
         super().__init__()
         self.task = task
         self.transform = transform
-        self._samples: DataFrame
+        self._samples: DataFrame = None
 
     def __len__(self) -> int:
         """Get length of the dataset."""

--- a/anomalib/data/btech.py
+++ b/anomalib/data/btech.py
@@ -269,7 +269,7 @@ class BTech(AnomalibDataModule):
             seed=seed,
         )
 
-        self.root = Path(root) if isinstance(root, str) else root
+        self.root = Path(root)
         self.category = Path(category)
 
         transform_train = get_transforms(

--- a/anomalib/data/btech.py
+++ b/anomalib/data/btech.py
@@ -182,7 +182,7 @@ class BTech(AnomalibDataModule):
 
     Args:
 
-        root (str): Path to the BTech dataset.
+        root (Path | str): Path to the BTech dataset.
         category (str): Name of the BTech category.
         image_size (int | tuple[int, int] | None, optional): Variable to which image is resized. Defaults to None.
         center_crop (int | tuple[int, int] | None, optional): When provided, the images will be center-cropped to the
@@ -241,7 +241,7 @@ class BTech(AnomalibDataModule):
 
     def __init__(
         self,
-        root: str,
+        root: Path | str,
         category: str,
         image_size: int | tuple[int, int] | None = None,
         center_crop: int | tuple[int, int] | None = None,
@@ -269,7 +269,7 @@ class BTech(AnomalibDataModule):
             seed=seed,
         )
 
-        self.root = Path(root)
+        self.root = Path(root) if isinstance(root, str) else root
         self.category = Path(category)
 
         transform_train = get_transforms(

--- a/anomalib/data/mvtec.py
+++ b/anomalib/data/mvtec.py
@@ -153,7 +153,7 @@ class MVTecDataset(AnomalibDataset):
         task (TaskType): Task type, ``classification``, ``detection`` or ``segmentation``
         transform (A.Compose): Albumentations Compose object describing the transforms that are applied to the inputs.
         split (str | Split | None): Split of the dataset, usually Split.TRAIN or Split.TEST
-        root (str): Path to the root of the dataset
+        root (Path | str): Path to the root of the dataset
         category (str): Sub-category of the dataset, e.g. 'bottle'
     """
 
@@ -161,7 +161,7 @@ class MVTecDataset(AnomalibDataset):
         self,
         task: TaskType,
         transform: A.Compose,
-        root: str,
+        root: Path | str,
         category: str,
         split: str | Split | None = None,
     ) -> None:
@@ -178,7 +178,7 @@ class MVTec(AnomalibDataModule):
     """MVTec Datamodule.
 
     Args:
-        root (str): Path to the root of the dataset
+        root (Path | str): Path to the root of the dataset
         category (str): Category of the MVTec dataset (e.g. "bottle" or "cable").
         image_size (int | tuple[int, int] | None, optional): Size of the input image.
             Defaults to None.
@@ -204,7 +204,7 @@ class MVTec(AnomalibDataModule):
 
     def __init__(
         self,
-        root: str,
+        root: Path | str,
         category: str,
         image_size: int | tuple[int, int] | None = None,
         center_crop: int | tuple[int, int] | None = None,
@@ -232,7 +232,7 @@ class MVTec(AnomalibDataModule):
             seed=seed,
         )
 
-        self.root = Path(root)
+        self.root = Path(root) if isinstance(root, str) else root
         self.category = Path(category)
 
         transform_train = get_transforms(

--- a/anomalib/data/mvtec.py
+++ b/anomalib/data/mvtec.py
@@ -232,7 +232,7 @@ class MVTec(AnomalibDataModule):
             seed=seed,
         )
 
-        self.root = Path(root) if isinstance(root, str) else root
+        self.root = Path(root)
         self.category = Path(category)
 
         transform_train = get_transforms(

--- a/anomalib/data/shanghaitech.py
+++ b/anomalib/data/shanghaitech.py
@@ -267,7 +267,7 @@ class ShanghaiTech(AnomalibVideoDataModule):
             seed=seed,
         )
 
-        self.root = Path(root) if isinstance(root, str) else root
+        self.root = Path(root)
         self.scene = scene
 
         transform_train = get_transforms(

--- a/anomalib/data/shanghaitech.py
+++ b/anomalib/data/shanghaitech.py
@@ -215,7 +215,7 @@ class ShanghaiTech(AnomalibVideoDataModule):
     """ShanghaiTech DataModule class.
 
     Args:
-        root (str): Path to the root of the dataset
+        root (Path | str): Path to the root of the dataset
         scene (int): Index of the dataset scene (category) in range [1, 13]
         clip_length_in_frames (int, optional): Number of video frames in each clip.
         frames_between_clips (int, optional): Number of frames between each consecutive video clip.
@@ -241,7 +241,7 @@ class ShanghaiTech(AnomalibVideoDataModule):
 
     def __init__(
         self,
-        root: str,
+        root: Path | str,
         scene: int,
         clip_length_in_frames: int = 1,
         frames_between_clips: int = 1,
@@ -267,7 +267,7 @@ class ShanghaiTech(AnomalibVideoDataModule):
             seed=seed,
         )
 
-        self.root = Path(root)
+        self.root = Path(root) if isinstance(root, str) else root
         self.scene = scene
 
         transform_train = get_transforms(

--- a/anomalib/data/ucsd_ped.py
+++ b/anomalib/data/ucsd_ped.py
@@ -237,7 +237,7 @@ class UCSDped(AnomalibVideoDataModule):
             seed=seed,
         )
 
-        self.root = Path(root) if isinstance(root, str) else root
+        self.root = Path(root)
         self.category = category
 
         transform_train = get_transforms(

--- a/anomalib/data/ucsd_ped.py
+++ b/anomalib/data/ucsd_ped.py
@@ -149,7 +149,7 @@ class UCSDpedDataset(AnomalibVideoDataset):
 
     Args:
         task (TaskType): Task type, 'classification', 'detection' or 'segmentation'
-        root (str): Path to the root of the dataset
+        root (Path | str): Path to the root of the dataset
         category (str): Sub-category of the dataset, e.g. 'bottle'
         transform (A.Compose): Albumentations Compose object describing the transforms that are applied to the inputs.
         split (str | Split | None): Split of the dataset, usually Split.TRAIN or Split.TEST
@@ -182,7 +182,7 @@ class UCSDped(AnomalibVideoDataModule):
     """UCSDped DataModule class.
 
     Args:
-        root (str): Path to the root of the dataset
+        root (Path | str): Path to the root of the dataset
         category (str): Sub-category of the dataset, e.g. 'bottle'
         clip_length_in_frames (int, optional): Number of video frames in each clip.
         frames_between_clips (int, optional): Number of frames between each consecutive video clip.
@@ -211,7 +211,7 @@ class UCSDped(AnomalibVideoDataModule):
 
     def __init__(
         self,
-        root: str,
+        root: Path | str,
         category: str,
         clip_length_in_frames: int = 1,
         frames_between_clips: int = 1,
@@ -237,7 +237,7 @@ class UCSDped(AnomalibVideoDataModule):
             seed=seed,
         )
 
-        self.root = Path(root)
+        self.root = Path(root) if isinstance(root, str) else root
         self.category = category
 
         transform_train = get_transforms(

--- a/anomalib/data/visa.py
+++ b/anomalib/data/visa.py
@@ -142,7 +142,7 @@ class Visa(AnomalibDataModule):
             seed=seed,
         )
 
-        self.root = Path(root) if isinstance(root, str) else root
+        self.root = Path(root)
         self.split_root = self.root / "visa_pytorch"
         self.category = category
 

--- a/anomalib/data/visa.py
+++ b/anomalib/data/visa.py
@@ -88,7 +88,7 @@ class Visa(AnomalibDataModule):
     """VisA Datamodule.
 
     Args:
-        root (str): Path to the root of the dataset
+        root (Path | str): Path to the root of the dataset
         category (str): Category of the MVTec dataset (e.g. "bottle" or "cable").
         image_size (int | tuple[int, int] | None, optional): Size of the input image.
             Defaults to None.
@@ -114,7 +114,7 @@ class Visa(AnomalibDataModule):
 
     def __init__(
         self,
-        root: str,
+        root: Path | str,
         category: str,
         image_size: int | tuple[int, int] | None = None,
         center_crop: int | tuple[int, int] | None = None,
@@ -142,7 +142,7 @@ class Visa(AnomalibDataModule):
             seed=seed,
         )
 
-        self.root = Path(root)
+        self.root = Path(root) if isinstance(root, str) else root
         self.split_root = self.root / "visa_pytorch"
         self.category = category
 


### PR DESCRIPTION
# Description
- Change the type of `root` variable from `str` to `str | Path`.

# Motivation
- With this change, it will be easier to pass `Path` objects when using datamodules via the API.


## Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
