### PR TITLE
Fix minor logic bug detecting empty list of images

### DIFF
--- a/anomalib/data/utils/image.py
+++ b/anomalib/data/utils/image.py
@@ -37,7 +37,7 @@ def get_image_filenames(path: str | Path) -> list[Path]:
     if path.is_dir():
         image_filenames = [p for p in path.glob("**/*") if p.suffix in IMG_EXTENSIONS]
 
-    if image_filenames:
+    if not image_filenames:
         raise ValueError(f"Found 0 images in {path}")
 
     return image_filenames


### PR DESCRIPTION
This fixes a regression in `get_image_filenames()` caused by changing from a len(image_filenames) == 0 check in a previous commit. Empty lists report as `False`, not `True`, as caught by this, so added a `not` to fix.

# Description

- Provide a summary of the modification as well as the issue that has been resolved. List any dependencies that this modification necessitates.

- Fixes # (issue)

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
