### PR TITLE
Remove codacy from ci docs

### DIFF
--- a/.ci/README.md
+++ b/.ci/README.md
@@ -51,11 +51,3 @@
    Follow the instructions on the screen to complete the installation.
 
 1. Now the container is ready. Type `exit` to leave the container.
-
-1. Start github actions runner in detached mode in the container and set the
-   codacy token and the anomalib dataset environment variables.
-
-   ```bash
-   sudo docker exec -d anomalib-ci-container /bin/bash -c \
-   "export ANOMALIB_DATASET_PATH=/home/user/datasets;export CODACY_PROJECT_TOKEN=<codacy-project-token> && /home/user/actions-runner/run.sh"
-   ```


### PR DESCRIPTION
# Description

- We don't need to pass token as it is not being used by the ci
