### PR TITLE
Add ruff as the main linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       # list of supported hooks: https://pre-commit.com/hooks.html
       - id: trailing-whitespace
@@ -15,7 +15,7 @@ repos:
 
   # python code formatting
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 23.1.0
     hooks:
       - id: black
 
@@ -28,7 +28,7 @@ repos:
 
   # python static type checking
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v0.971"
+    rev: "v1.0.1"
     hooks:
       - id: mypy
         additional_dependencies: [types-PyYAML]
@@ -36,25 +36,23 @@ repos:
 
   # notebooks.
   - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.4.0
+    rev: 1.6.3
     hooks:
       - id: nbqa-black
-      - id: nbqa-isort
-      - id: nbqa-flake8
-      - id: nbqa-pylint
+      - id: nbqa-ruff
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.7.1
+    rev: v3.0.0-alpha.4
     hooks:
       - id: prettier
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.32.2
+    rev: v0.33.0
     hooks:
       - id: markdownlint
 
   - repo: https://github.com/AleksaC/hadolint-py
-    rev: v2.10.0
+    rev: v2.12.0.2
     hooks:
       - id: hadolint
         name: Lint Dockerfiles

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,30 +19,12 @@ repos:
     hooks:
       - id: black
 
-  # python import sorting
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.11.5
+  # Ruff version.
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: "v0.0.253"
     hooks:
-      - id: isort
-
-  # python code analysis
-  - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
-    hooks:
-      - id: flake8
-        args: ["--max-line-length=120", "--ignore=E203,W503"]
+      - id: ruff
         exclude: "tests"
-
-  # python linting
-  - repo: https://github.com/PyCQA/pylint
-    rev: v2.14.5
-    hooks:
-      - id: pylint
-        name: pylint
-        entry: pylint --score=no
-        language: system
-        types: [python]
-        exclude: "tests|docs"
 
   # python static type checking
   - repo: https://github.com/pre-commit/mirrors-mypy
@@ -51,22 +33,6 @@ repos:
       - id: mypy
         additional_dependencies: [types-PyYAML]
         exclude: "tests"
-
-  - repo: https://github.com/PyCQA/pydocstyle
-    rev: 6.1.1
-    hooks:
-      - id: pydocstyle
-        additional_dependencies: [toml]
-        name: pydocstyle
-        entry: pydocstyle
-        language: python
-        types: [python]
-        exclude: "tests|docs"
-
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
-    hooks:
-      - id: pyupgrade
 
   # notebooks.
   - repo: https://github.com/nbQA-dev/nbQA

--- a/anomalib/data/utils/augmenter.py
+++ b/anomalib/data/utils/augmenter.py
@@ -47,7 +47,6 @@ class Augmenter:
         p_anomalous: float = 0.5,
         beta: float | tuple[float, float] = (0.2, 1.0),
     ):
-
         self.p_anomalous = p_anomalous
         self.beta = beta
 

--- a/anomalib/deploy/inferencers/torch_inferencer.py
+++ b/anomalib/deploy/inferencers/torch_inferencer.py
@@ -44,7 +44,6 @@ class TorchInferencer(Inferencer):
         meta_data_path: str | Path | None = None,
         device: str = "auto",
     ) -> None:
-
         self.device = self._get_device(device)
 
         # Check and load the configuration

--- a/anomalib/models/csflow/torch_model.py
+++ b/anomalib/models/csflow/torch_model.py
@@ -519,7 +519,6 @@ class CsFlowModel(nn.Module):
         clamp: int = 3,
         num_channels: int = 3,
     ) -> None:
-
         super().__init__()
         self.input_dims = (num_channels, *input_size)
         self.clamp = clamp

--- a/anomalib/models/fastflow/loss.py
+++ b/anomalib/models/fastflow/loss.py
@@ -23,6 +23,6 @@ class FastflowLoss(nn.Module):
             Tensor: Fastflow loss computed based on the hidden variables and the log of the Jacobians.
         """
         loss = torch.tensor(0.0, device=hidden_variables[0].device)  # pylint: disable=not-callable
-        for (hidden_variable, jacobian) in zip(hidden_variables, jacobians):
+        for hidden_variable, jacobian in zip(hidden_variables, jacobians):
             loss += torch.mean(0.5 * torch.sum(hidden_variable**2, dim=(1, 2, 3)) - jacobian)
         return loss

--- a/anomalib/models/ganomaly/lightning_model.py
+++ b/anomalib/models/ganomaly/lightning_model.py
@@ -208,7 +208,6 @@ class GanomalyLightning(Ganomaly):
     """
 
     def __init__(self, hparams: DictConfig | ListConfig) -> None:
-
         super().__init__(
             batch_size=hparams.dataset.train_batch_size,
             input_size=hparams.model.input_size,

--- a/anomalib/models/rkde/region_extractor.py
+++ b/anomalib/models/rkde/region_extractor.py
@@ -123,7 +123,6 @@ class RegionExtractor(nn.Module):
 
         processed_boxes: list[Tensor] = []
         for boxes, scores in zip(pred_boxes, pred_scores):
-
             # remove small boxes
             keep = box_ops.remove_small_boxes(boxes, min_size=self.min_size)
             boxes, scores = boxes[keep], scores[keep]

--- a/anomalib/pre_processing/tiler.py
+++ b/anomalib/pre_processing/tiler.py
@@ -154,7 +154,6 @@ class Tiler:
         mode: str = "padding",
         tile_count: int = 4,
     ) -> None:
-
         self.tile_size_h, self.tile_size_w = self.__validate_size_type(tile_size)
         self.tile_count = tile_count
 

--- a/anomalib/utils/callbacks/nncf/utils.py
+++ b/anomalib/utils/callbacks/nncf/utils.py
@@ -58,7 +58,7 @@ class InitLoader(PTInitializingDataLoader):
 
 
 def wrap_nncf_model(
-    model: nn.Module, config: dict, dataloader: DataLoader = None, init_state_dict: dict = None
+    model: nn.Module, config: dict, dataloader: DataLoader, init_state_dict: dict
 ) -> tuple[CompressionAlgorithmController, NNCFNetwork]:
     """Wrap model by NNCF.
 

--- a/anomalib/utils/metrics/aupro.py
+++ b/anomalib/utils/metrics/aupro.py
@@ -36,7 +36,7 @@ class AUPRO(Metric):
         compute_on_step: bool = True,
         dist_sync_on_step: bool = False,
         process_group: Any | None = None,
-        dist_sync_fn: Callable = None,
+        dist_sync_fn: Callable | None = None,
         fpr_limit: float = 0.3,
     ) -> None:
         super().__init__(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,57 +6,58 @@ build-backend = "setuptools.build_meta"
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# ISORT CONFIGURATION.                                                        #
-[tool.isort]
-profile = "black"
-known_first_party = "wandb"
-sections = ['FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER']
-
-
-# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # BLACK CONFIGURATION                                                         #
 [tool.black]
 line-length = 120
 
-[tool.flake8]
-ignore = ["E203", "W503"]
-max-line-length = 120
-
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# PYLINT CONFIGURATION                                                        #
-[tool.pylint.main]
-extension-pkg-whitelist = "cv2"
-ignore = ["tests", "docs"]
-ignored-modules = "cv2"
+# RUFF CONFIGURATION                                                          #
+[tool.ruff]
+# Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
+select = ["E", "F"]
+ignore = []
 
-[tool.pylint.messages_control]
-disable = [
-    "duplicate-code",
-    "arguments-differ",
-    "fixme",
-    "import-error",
-    "too-many-arguments",
-    "too-many-branches",
-    "too-many-instance-attributes",
-    "too-many-locals",
-    "too-few-public-methods",
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+fixable = ["A", "B", "C", "D", "E", "F"]
+unfixable = []
+
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
 ]
 
-[tool.pylint.typecheck]
-generated-members = ["numpy.*", "torch.*"]
+# Same as Black.
+line-length = 120
 
-[tool.pylint.basic]
-good-names = ["e", "i", "id"]
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-[tool.pylint.format]
-max-line-length = 120
+# Assume Python 3.8.
+target-version = "py38"
 
-[tool.pylint.design]
-max-parents = 15
-
-[tool.pylint.similarities]
-min-similarity-lines = 5
+[tool.ruff.mccabe]
+# Unlike Flake8, default to a complexity level of 10.
+max-complexity = 10
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -83,23 +84,8 @@ exclude_lines = [
     "raise ValueError",
 ]
 
-[tool.pydocstyle]
-inherit = false
-ignore = [
-    "D107", # Missing docstring in __init__
-    "D202", # No blank lines allowed after function docstring
-    "D203", # 1 blank line required before class docstring
-    "D213", # Multi-line docstring summary should start at the second line
-    "D401", # First line should be in imperative mood; try rephrasing
-    "D404", # First word of the docstring should not be This
-    "D406", # Section name should end with a newline
-    "D407", # Missing dashed underline after section
-    "D413", # Missing blank line after last section
-]
-
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # NBQA CONFIGURATION                                                          #
 [tool.nbqa.addopts]
-pylint = ["--disable=C0103,C0114,C0116,C0413,E0401,R0801,W0106"]
-flake8 = ["--ignore=E203,W503,E402", "--max-line-length=120"]
+ruff = ["--ignore=E402"]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,7 +1,5 @@
 black==22.6.0
-isort==5.11.5
-pylint>=2.14.5
-flake8>=4.0.1
+ruff
 pytest
 pre-commit>=2.15.0
 tox>=3.24.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
-black==22.6.0
+black
 ruff
 pytest
-pre-commit>=2.15.0
-tox>=3.24.3
-nbmake>=1.3.5
+pre-commit
+tox
+nbmake

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,3 @@
-black
-ruff
-pytest
 pre-commit
+pytest
 tox
-nbmake

--- a/tests/helpers/aupro_reference.py
+++ b/tests/helpers/aupro_reference.py
@@ -134,7 +134,6 @@ def collect_anomaly_scores(anomaly_maps, ground_truth_maps):
     # Collect anomaly scores within each ground truth region and for all potential fp pixels.
     ok_index = 0
     for gt_map, prediction in zip(ground_truth_maps, anomaly_maps):
-
         # Compute the connected components in the ground truth map.
         labeled, n_components = label(gt_map, structure)
 

--- a/tools/inference/gradio_inference.py
+++ b/tools/inference/gradio_inference.py
@@ -26,9 +26,9 @@ def get_args() -> Namespace:
     Example:
 
         Example for Torch Inference.
-        >>> python tools/inference/gradio_inference.py  \                                                                                     ─╯
+        >>> python tools/inference/gradio_inference.py  \
         ...     --config ./anomalib/models/padim/config.yaml    \
-        ...     --weights ./results/padim/mvtec/bottle/weights/model.ckpt   # noqa: E501    #pylint: disable=line-too-long
+        ...     --weights ./results/padim/mvtec/bottle/weights/model.ckpt
 
     Returns:
         Namespace: List of arguments.


### PR DESCRIPTION
# Description

- Add ruff as the main linter
- Remove isort, flake8, pylint and pydocstyle
- Update the pre-commit versions.
- Remove redundant packages from `requirements/dev.txt`

## Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
