### PR TITLE
Fixed openvino_inferencer in gradio_inference

### DIFF
--- a/tools/inference/gradio_inference.py
+++ b/tools/inference/gradio_inference.py
@@ -68,7 +68,7 @@ def get_inferencer(config_path: Path, weight_path: Path, metadata_path: Path | N
 
     elif extension in (".onnx", ".bin", ".xml"):
         openvino_inferencer = getattr(module, "OpenVINOInferencer")
-        inferencer = openvino_inferencer(config=config_path, path=weight_path, metadata_path=metadata_path)
+        inferencer = openvino_inferencer(path=weight_path, metadata_path=metadata_path)
 
     else:
         raise ValueError(

--- a/tools/inference/gradio_inference.py
+++ b/tools/inference/gradio_inference.py
@@ -34,7 +34,7 @@ def get_args() -> Namespace:
         Namespace: List of arguments.
     """
     parser = ArgumentParser()
-    parser.add_argument("--config", type=Path, required=True, help="Path to a config file")
+    parser.add_argument("--config", type=Path, required=False, help="Path to a config file")
     parser.add_argument("--weights", type=Path, required=True, help="Path to model weights")
     parser.add_argument("--metadata", type=Path, required=False, help="Path to a JSON file containing the metadata.")
     parser.add_argument("--share", type=bool, required=False, default=False, help="Share Gradio `share_url`")
@@ -63,10 +63,16 @@ def get_inferencer(config_path: Path, weight_path: Path, metadata_path: Path | N
     inferencer: Inferencer
     module = import_module("anomalib.deploy")
     if extension in (".ckpt"):
+        if config_path is None:
+            raise ValueError("When using Torch Inferencer, the following arguments are required: --config")
+
         torch_inferencer = getattr(module, "TorchInferencer")
         inferencer = torch_inferencer(config=config_path, model_source=weight_path, metadata_path=metadata_path)
 
     elif extension in (".onnx", ".bin", ".xml"):
+        if metadata_path is None:
+            raise ValueError("When using OpenVINO Inferencer, the following arguments are required: --metadata")
+
         openvino_inferencer = getattr(module, "OpenVINOInferencer")
         inferencer = openvino_inferencer(path=weight_path, metadata_path=metadata_path)
 


### PR DESCRIPTION
# Description

Fixed OpenVINOInferencer instantiation in gradio_inference. OpenVINOInferencer now no longer takes config parameter. This was previously fixed in openvino_inference, but not in gradio_inference, so I fixed it here as well.

- Fixes #971 

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
