### PR TITLE
always reorder for aupr metric

### DIFF
--- a/src/anomalib/utils/metrics/aupr.py
+++ b/src/anomalib/utils/metrics/aupr.py
@@ -29,10 +29,7 @@ class AUPR(PrecisionRecallCurve):
         rec: Tensor
 
         prec, rec = self._compute()
-        # TODO: use stable sort after upgrading to pytorch 1.9.x (https://github.com/openvinotoolkit/anomalib/issues/92)
-        if not (torch.all(prec.diff() <= 0) or torch.all(prec.diff() >= 0)):
-            return auc(rec, prec, reorder=True)  # only reorder if rec is not increasing or decreasing
-        return auc(rec, prec)
+        return auc(rec, prec, reorder=True)
 
     def update(self, preds: Tensor, target: Tensor) -> None:  # type: ignore
         """Update state with new values.

--- a/src/anomalib/utils/metrics/aupr.py
+++ b/src/anomalib/utils/metrics/aupr.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import torch
 from matplotlib.figure import Figure
 from torch import Tensor
 from torchmetrics import PrecisionRecallCurve


### PR DESCRIPTION
# Description

This PR mirrors the changes in #944 and #945 , apply for AUPR metric.

## Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
