### PR TITLE
Cuda 11.4 dockerfile fix

### DIFF
--- a/.ci/cuda11.4.Dockerfile
+++ b/.ci/cuda11.4.Dockerfile
@@ -36,6 +36,13 @@ RUN add-apt-repository ppa:git-core/ppa &&\
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# Prettier requires atleast nodejs 10 and actions/checkout requires nodejs 16
+RUN curl -sL https://deb.nodesource.com/setup_current.x > nodesetup.sh && \
+    bash - nodesetup.sh && \
+    apt-get install --no-install-recommends -y nodejs && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 # Create a non-root user
 RUN useradd -m user
 USER user
@@ -46,13 +53,6 @@ RUN curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh >
     rm ~/miniconda.sh
 ENV PATH "/home/user/conda/bin:${PATH}"
 RUN conda install python=3.8
-
-# Prettier requires atleast nodejs 10 and actions/checkout requires nodejs 16
-RUN curl -sL https://deb.nodesource.com/setup_current.x > nodesetup.sh && \
-    bash - nodesetup.sh && \
-    apt-get install --no-install-recommends -y nodejs && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
 
 
 #########################################################


### PR DESCRIPTION
# Description

Here is a proposed fix to a bug I've been encountering. Right off the bat, I have not created an issue on GitHub corresponding to my problem, but I can do it if needed.

# Issue description

Issue : VSCode throwing following error while building Anomalib container :
```
 > [python_base_cuda11.4 7/7] RUN curl -sL https://deb.nodesource.com/setup_current.x > nodesetup.sh &&     bash - nodesetup.sh &&     apt-get install --no-install-recommends -y nodejs &&     apt-get clean &&     rm -rf /var/lib/apt/lists/*:
#0 0.277 /bin/sh: 1: cannot create nodesetup.sh: Permission denied 
``` 
This error occurred on two separate computers, including one where I never installed Anomalib (so it couldn't be linked to cached container issues)

Steps to reproduce :
- Clone anomalib locally
- Open anomalib folder with VSCode
- Select Reopen in Container
- Anomalib throws error

OS information:
- OS: Linux Mint 21.1
- Python version: 3.10.6
- Anomalib version: Latest commit (3b00ecff1668d11b770eedf018fb681f0b9afbcc)
- VSCode version : 1.77.3

Expected behaviour : Anomalib container builds without error

Complete logs :
```
[2023-04-20T18:34:56.470Z] Dev Containers 0.288.1 in VS Code 1.77.3 (704ed70d4fd1c6bd6342c436f1ede30d1cff4710).
[2023-04-20T18:34:56.470Z] Start: Resolving Remote
[2023-04-20T18:34:56.539Z] Setting up container for folder or workspace: /home/philippe/Documents/anomalib
[2023-04-20T18:34:56.542Z] Start: Check Docker is running
[2023-04-20T18:34:56.543Z] Start: Run: docker version --format {{.Server.APIVersion}}
[2023-04-20T18:34:56.580Z] Stop (37 ms): Run: docker version --format {{.Server.APIVersion}}
[2023-04-20T18:34:56.580Z] Server API version: 1.42
[2023-04-20T18:34:56.581Z] Stop (39 ms): Check Docker is running
[2023-04-20T18:34:56.582Z] Start: Run: docker volume ls -q
[2023-04-20T18:34:56.602Z] Stop (20 ms): Run: docker volume ls -q
[2023-04-20T18:34:56.603Z] Start: Run: docker ps -q -a --filter label=vsch.local.folder=/home/philippe/Documents/anomalib --filter label=vsch.quality=stable
[2023-04-20T18:34:56.622Z] Stop (19 ms): Run: docker ps -q -a --filter label=vsch.local.folder=/home/philippe/Documents/anomalib --filter label=vsch.quality=stable
[2023-04-20T18:34:56.623Z] Start: Run: docker ps -q -a --filter label=devcontainer.local_folder=/home/philippe/Documents/anomalib --filter label=devcontainer.config_file=/home/philippe/Documents/anomalib/.devcontainer/devcontainer.json
[2023-04-20T18:34:56.641Z] Stop (18 ms): Run: docker ps -q -a --filter label=devcontainer.local_folder=/home/philippe/Documents/anomalib --filter label=devcontainer.config_file=/home/philippe/Documents/anomalib/.devcontainer/devcontainer.json
[2023-04-20T18:34:56.642Z] Start: Run: docker ps -q -a --filter label=devcontainer.local_folder=/home/philippe/Documents/anomalib
[2023-04-20T18:34:56.661Z] Stop (19 ms): Run: docker ps -q -a --filter label=devcontainer.local_folder=/home/philippe/Documents/anomalib
[2023-04-20T18:34:56.662Z] Start: Run: docker ps -q -a --filter label=devcontainer.local_folder=/home/philippe/Documents/anomalib
[2023-04-20T18:34:56.680Z] Stop (18 ms): Run: docker ps -q -a --filter label=devcontainer.local_folder=/home/philippe/Documents/anomalib
[2023-04-20T18:34:56.681Z] Start: Run: /usr/share/code/code --ms-enable-electron-run-as-node /home/philippe/.vscode/extensions/ms-vscode-remote.remote-containers-0.288.1/dist/spec-node/devContainersSpecCLI.js up --user-data-folder /home/philippe/.config/Code/User/globalStorage/ms-vscode-remote.remote-containers/data --container-session-data-folder /tmp/devcontainers-9405e341-37ce-4578-a003-7143cfc4a18d1682015695578 --workspace-folder /home/philippe/Documents/anomalib --workspace-mount-consistency cached --id-label devcontainer.local_folder=/home/philippe/Documents/anomalib --id-label devcontainer.config_file=/home/philippe/Documents/anomalib/.devcontainer/devcontainer.json --log-level debug --log-format json --config /home/philippe/Documents/anomalib/.devcontainer/devcontainer.json --default-user-env-probe loginInteractiveShell --mount type=volume,source=vscode,target=/vscode,external=true --skip-post-create --update-remote-user-uid-default on --mount-workspace-git-root true
[2023-04-20T18:34:56.986Z] @devcontainers/cli 0.35.0. Node.js v16.14.2. linux 5.15.0-70-generic x64.
[2023-04-20T18:34:56.986Z] Start: Run: docker buildx version
[2023-04-20T18:34:57.077Z] Stop (91 ms): Run: docker buildx version
[2023-04-20T18:34:57.078Z] github.com/docker/buildx v0.10.4 c513d34
[2023-04-20T18:34:57.078Z] 
[2023-04-20T18:34:57.078Z] Start: Resolving Remote
[2023-04-20T18:34:57.081Z] Start: Run: git rev-parse --show-cdup
[2023-04-20T18:34:57.087Z] Stop (6 ms): Run: git rev-parse --show-cdup
[2023-04-20T18:34:57.088Z] Start: Run: docker ps -q -a --filter label=devcontainer.local_folder=/home/philippe/Documents/anomalib --filter label=devcontainer.config_file=/home/philippe/Documents/anomalib/.devcontainer/devcontainer.json
[2023-04-20T18:34:57.105Z] Stop (17 ms): Run: docker ps -q -a --filter label=devcontainer.local_folder=/home/philippe/Documents/anomalib --filter label=devcontainer.config_file=/home/philippe/Documents/anomalib/.devcontainer/devcontainer.json
[2023-04-20T18:34:57.109Z] Start: Run: docker inspect --type image nvidia/cuda:11.4.0-devel-ubuntu20.04
[2023-04-20T18:34:57.127Z] Stop (18 ms): Run: docker inspect --type image nvidia/cuda:11.4.0-devel-ubuntu20.04
[2023-04-20T18:34:58.627Z] local container features stored at: /home/philippe/.vscode/extensions/ms-vscode-remote.remote-containers-0.288.1/dist/node_modules/vscode-dev-containers/container-features
[2023-04-20T18:34:58.629Z] Start: Run: tar --no-same-owner -x -f -
[2023-04-20T18:34:58.649Z] Stop (20 ms): Run: tar --no-same-owner -x -f -
[2023-04-20T18:34:58.652Z] Start: Run: docker buildx build --load --build-arg BUILDKIT_INLINE_CACHE=1 -f /tmp/devcontainercli-philippe/container-features/0.35.0-1682015698626/Dockerfile-with-features -t vsc-anomalib-af6c1294e531c5474c6d34c7669c5b6c47f6e493180f5b44c755a1d87558ed4a --target dev_containers_target_stage --build-arg _DEV_CONTAINERS_BASE_IMAGE=anomalib_development_env /home/philippe/Documents/anomalib
[2023-04-20T18:34:58.834Z] 
[2023-04-20T18:34:58.834Z] [+] Building 0.0s (0/2)                                                         
[2023-04-20T18:34:58.983Z] [+] Building 0.2s (2/3)                                                         
 => [internal] load .dockerignore                                          0.0s
 => => transferring context: 182B                                          0.0s
 => [internal] load build definition from Dockerfile-with-features         0.0s
 => => transferring dockerfile: 3.34kB                                     0.0s
 => [internal] load metadata for docker.io/nvidia/cuda:11.4.0-devel-ubunt  0.1s
[2023-04-20T18:34:59.134Z] [+] Building 0.3s (2/3)                                                         
 => [internal] load .dockerignore                                          0.0s
[2023-04-20T18:34:59.134Z]  => => transferring context: 182B                                          0.0s
 => [internal] load build definition from Dockerfile-with-features         0.0s
 => => transferring dockerfile: 3.34kB                                     0.0s
 => [internal] load metadata for docker.io/nvidia/cuda:11.4.0-devel-ubunt  0.2s
[2023-04-20T18:34:59.285Z] [+] Building 0.5s (2/3)                                                         
 => [internal] load .dockerignore                                          0.0s
 => => transferring context: 182B                                          0.0s
 => [internal] load build definition from Dockerfile-with-features         0.0s
[2023-04-20T18:34:59.285Z]  => => transferring dockerfile: 3.34kB                                     0.0s
 => [internal] load metadata for docker.io/nvidia/cuda:11.4.0-devel-ubunt  0.4s
[2023-04-20T18:34:59.435Z] [+] Building 0.6s (2/3)                                                         
 => [internal] load .dockerignore                                          0.0s
 => => transferring context: 182B                                          0.0s
 => [internal] load build definition from Dockerfile-with-features         0.0s
 => => transferring dockerfile: 3.34kB                                     0.0s
 => [internal] load metadata for docker.io/nvidia/cuda:11.4.0-devel-ubunt  0.5s
[2023-04-20T18:34:59.585Z] [+] Building 0.8s (2/3)                                                         
 => [internal] load .dockerignore                                          0.0s
 => => transferring context: 182B                                          0.0s
[2023-04-20T18:34:59.585Z]  => [internal] load build definition from Dockerfile-with-features         0.0s
 => => transferring dockerfile: 3.34kB                                     0.0s
 => [internal] load metadata for docker.io/nvidia/cuda:11.4.0-devel-ubunt  0.7s
[2023-04-20T18:34:59.693Z] [+] Building 0.9s (3/13)                                                        
 => [internal] load .dockerignore                                          0.0s
 => => transferring context: 182B                                          0.0s
 => [internal] load build definition from Dockerfile-with-features         0.0s
 => => transferring dockerfile: 3.34kB                                     0.0s
[2023-04-20T18:34:59.693Z]  => [internal] load metadata for docker.io/nvidia/cuda:11.4.0-devel-ubunt  0.8s
[2023-04-20T18:34:59.843Z] 
[2023-04-20T18:34:59.843Z] [+] Building 1.0s (10/18)                                                       
 => [internal] load .dockerignore                                          0.0s
 => => transferring context: 182B                                          0.0s
 => [internal] load build definition from Dockerfile-with-features         0.0s
 => => transferring dockerfile: 3.34kB                                     0.0s
 => [internal] load metadata for docker.io/nvidia/cuda:11.4.0-devel-ubunt  0.8s
 => [internal] load build context                                          0.1s
 => => transferring context: 158B                                          0.0s
 => [python_base_cuda11.4 1/7] FROM docker.io/nvidia/cuda:11.4.0-devel-ub  0.0s
 => CACHED [python_base_cuda11.4 2/7] RUN apt-get update &&     apt-get i  0.0s
 => CACHED [python_base_cuda11.4 3/7] RUN add-apt-repository ppa:git-core  0.0s
 => CACHED [python_base_cuda11.4 4/7] RUN useradd -m user                  0.0s
 => CACHED [python_base_cuda11.4 5/7] RUN curl https://repo.anaconda.com/  0.0s
 => CACHED [python_base_cuda11.4 6/7] RUN conda install python=3.8         0.0s
[2023-04-20T18:34:59.844Z] 
 => [python_base_cuda11.4 7/7] RUN curl -sL https://deb.nodesource.com/se  0.1s
[2023-04-20T18:34:59.993Z] [+] Building 1.2s (10/18)                                                       
 => [internal] load .dockerignore                                          0.0s
 => => transferring context: 182B                                          0.0s
 => [internal] load build definition from Dockerfile-with-features         0.0s
 => => transferring dockerfile: 3.34kB                                     0.0s
 => [internal] load metadata for docker.io/nvidia/cuda:11.4.0-devel-ubunt  0.8s
 => [internal] load build context                                          0.1s
 => => transferring context: 158B                                          0.0s
 => [python_base_cuda11.4 1/7] FROM docker.io/nvidia/cuda:11.4.0-devel-ub  0.0s
[2023-04-20T18:34:59.994Z]  => CACHED [python_base_cuda11.4 2/7] RUN apt-get update &&     apt-get i  0.0s
 => CACHED [python_base_cuda11.4 3/7] RUN add-apt-repository ppa:git-core  0.0s
 => CACHED [python_base_cuda11.4 4/7] RUN useradd -m user                  0.0s
 => CACHED [python_base_cuda11.4 5/7] RUN curl https://repo.anaconda.com/  0.0s
 => CACHED [python_base_cuda11.4 6/7] RUN conda install python=3.8         0.0s
 => [python_base_cuda11.4 7/7] RUN curl -sL https://deb.nodesource.com/se  0.3s
[2023-04-20T18:35:00.132Z] [+] Building 1.3s (10/18)                                                       
 => [internal] load .dockerignore                                          0.0s
 => => transferring context: 182B                                          0.0s
 => [internal] load build definition from Dockerfile-with-features         0.0s
 => => transferring dockerfile: 3.34kB                                     0.0s
 => [internal] load metadata for docker.io/nvidia/cuda:11.4.0-devel-ubunt  0.8s
 => [internal] load build context                                          0.1s
[2023-04-20T18:35:00.132Z]  => => transferring context: 158B                                          0.0s
 => [python_base_cuda11.4 1/7] FROM docker.io/nvidia/cuda:11.4.0-devel-ub  0.0s
 => CACHED [python_base_cuda11.4 2/7] RUN apt-get update &&     apt-get i  0.0s
 => CACHED [python_base_cuda11.4 3/7] RUN add-apt-repository ppa:git-core  0.0s
 => CACHED [python_base_cuda11.4 4/7] RUN useradd -m user                  0.0s
 => CACHED [python_base_cuda11.4 5/7] RUN curl https://repo.anaconda.com/  0.0s
 => CACHED [python_base_cuda11.4 6/7] RUN conda install python=3.8         0.0s
 => [python_base_cuda11.4 7/7] RUN curl -sL https://deb.nodesource.com/se  0.4s
 => => # /bin/sh: 1: cannot create nodesetup.sh: Permission denied             
[2023-04-20T18:35:00.183Z] [+] Building 1.3s (11/18)                                                       
 => [internal] load .dockerignore                                          0.0s
 => => transferring context: 182B                                          0.0s
 => [internal] load build definition from Dockerfile-with-features         0.0s
 => => transferring dockerfile: 3.34kB                                     0.0s
 => [internal] load metadata for docker.io/nvidia/cuda:11.4.0-devel-ubunt  0.8s
 => [internal] load build context                                          0.1s
 => => transferring context: 158B                                          0.0s
 => [python_base_cuda11.4 1/7] FROM docker.io/nvidia/cuda:11.4.0-devel-ub  0.0s
[2023-04-20T18:35:00.184Z]  => CACHED [python_base_cuda11.4 2/7] RUN apt-get update &&     apt-get i  0.0s
 => CACHED [python_base_cuda11.4 3/7] RUN add-apt-repository ppa:git-core  0.0s
 => CACHED [python_base_cuda11.4 4/7] RUN useradd -m user                  0.0s
 => CACHED [python_base_cuda11.4 5/7] RUN curl https://repo.anaconda.com/  0.0s
 => CACHED [python_base_cuda11.4 6/7] RUN conda install python=3.8         0.0s
 => ERROR [python_base_cuda11.4 7/7] RUN curl -sL https://deb.nodesource.  0.5s
                                                                                
------
 > [python_base_cuda11.4 7/7] RUN curl -sL https://deb.nodesource.com/setup_current.x > nodesetup.sh &&     bash - nodesetup.sh &&     apt-get install --no-install-recommends -y nodejs &&     apt-get clean &&     rm -rf /var/lib/apt/lists/*:
#0 0.438 /bin/sh: 1: cannot create nodesetup.sh: Permission denied
------
Dockerfile-with-features:53
--------------------
  52 |     # Prettier requires atleast nodejs 10 and actions/checkout requires nodejs 16
  53 | >>> RUN curl -sL https://deb.nodesource.com/setup_current.x > nodesetup.sh && \
  54 | >>>     bash - nodesetup.sh && \
  55 | >>>     apt-get install --no-install-recommends -y nodejs && \
  56 | >>>     apt-get clean && \
  57 | >>>     rm -rf /var/lib/apt/lists/*
  58 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c curl -sL https://deb.nodesource.com/setup_current.x > nodesetup.sh &&     bash - nodesetup.sh &&     apt-get install --no-install-recommends -y nodejs &&     apt-get clean &&     rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 2
[2023-04-20T18:35:00.391Z] Stop (1739 ms): Run: docker buildx build --load --build-arg BUILDKIT_INLINE_CACHE=1 -f /tmp/devcontainercli-philippe/container-features/0.35.0-1682015698626/Dockerfile-with-features -t vsc-anomalib-af6c1294e531c5474c6d34c7669c5b6c47f6e493180f5b44c755a1d87558ed4a --target dev_containers_target_stage --build-arg _DEV_CONTAINERS_BASE_IMAGE=anomalib_development_env /home/philippe/Documents/anomalib
[2023-04-20T18:35:00.392Z] Error: Command failed: docker buildx build --load --build-arg BUILDKIT_INLINE_CACHE=1 -f /tmp/devcontainercli-philippe/container-features/0.35.0-1682015698626/Dockerfile-with-features -t vsc-anomalib-af6c1294e531c5474c6d34c7669c5b6c47f6e493180f5b44c755a1d87558ed4a --target dev_containers_target_stage --build-arg _DEV_CONTAINERS_BASE_IMAGE=anomalib_development_env /home/philippe/Documents/anomalib
[2023-04-20T18:35:00.392Z]     at Sse (/home/philippe/.vscode/extensions/ms-vscode-remote.remote-containers-0.288.1/dist/spec-node/devContainersSpecCLI.js:1917:1698)
[2023-04-20T18:35:00.392Z]     at process.processTicksAndRejections (node:internal/process/task_queues:96:5)
[2023-04-20T18:35:00.392Z]     at async AD (/home/philippe/.vscode/extensions/ms-vscode-remote.remote-containers-0.288.1/dist/spec-node/devContainersSpecCLI.js:1916:3889)
[2023-04-20T18:35:00.393Z]     at async J7 (/home/philippe/.vscode/extensions/ms-vscode-remote.remote-containers-0.288.1/dist/spec-node/devContainersSpecCLI.js:1916:2808)
[2023-04-20T18:35:00.393Z]     at async $se (/home/philippe/.vscode/extensions/ms-vscode-remote.remote-containers-0.288.1/dist/spec-node/devContainersSpecCLI.js:1931:2626)
[2023-04-20T18:35:00.393Z]     at async Ah (/home/philippe/.vscode/extensions/ms-vscode-remote.remote-containers-0.288.1/dist/spec-node/devContainersSpecCLI.js:1931:3741)
[2023-04-20T18:35:00.393Z]     at async aae (/home/philippe/.vscode/extensions/ms-vscode-remote.remote-containers-0.288.1/dist/spec-node/devContainersSpecCLI.js:2059:17376)
[2023-04-20T18:35:00.393Z]     at async oae (/home/philippe/.vscode/extensions/ms-vscode-remote.remote-containers-0.288.1/dist/spec-node/devContainersSpecCLI.js:2059:17117)
[2023-04-20T18:35:00.402Z] Stop (3721 ms): Run: /usr/share/code/code --ms-enable-electron-run-as-node /home/philippe/.vscode/extensions/ms-vscode-remote.remote-containers-0.288.1/dist/spec-node/devContainersSpecCLI.js up --user-data-folder /home/philippe/.config/Code/User/globalStorage/ms-vscode-remote.remote-containers/data --container-session-data-folder /tmp/devcontainers-9405e341-37ce-4578-a003-7143cfc4a18d1682015695578 --workspace-folder /home/philippe/Documents/anomalib --workspace-mount-consistency cached --id-label devcontainer.local_folder=/home/philippe/Documents/anomalib --id-label devcontainer.config_file=/home/philippe/Documents/anomalib/.devcontainer/devcontainer.json --log-level debug --log-format json --config /home/philippe/Documents/anomalib/.devcontainer/devcontainer.json --default-user-env-probe loginInteractiveShell --mount type=volume,source=vscode,target=/vscode,external=true --skip-post-create --update-remote-user-uid-default on --mount-workspace-git-root true
[2023-04-20T18:35:00.403Z] Exit code 1
[2023-04-20T18:35:00.408Z] Command failed: /usr/share/code/code --ms-enable-electron-run-as-node /home/philippe/.vscode/extensions/ms-vscode-remote.remote-containers-0.288.1/dist/spec-node/devContainersSpecCLI.js up --user-data-folder /home/philippe/.config/Code/User/globalStorage/ms-vscode-remote.remote-containers/data --container-session-data-folder /tmp/devcontainers-9405e341-37ce-4578-a003-7143cfc4a18d1682015695578 --workspace-folder /home/philippe/Documents/anomalib --workspace-mount-consistency cached --id-label devcontainer.local_folder=/home/philippe/Documents/anomalib --id-label devcontainer.config_file=/home/philippe/Documents/anomalib/.devcontainer/devcontainer.json --log-level debug --log-format json --config /home/philippe/Documents/anomalib/.devcontainer/devcontainer.json --default-user-env-probe loginInteractiveShell --mount type=volume,source=vscode,target=/vscode,external=true --skip-post-create --update-remote-user-uid-default on --mount-workspace-git-root true
[2023-04-20T18:35:00.408Z] Exit code 1

```

# Fix
The error seems linked to the fact that the Docker user is created and used when setting up ```nodeinstall.sh```. Only root seems to be able to do it, so I simply moved the operation before the user is created.

## Changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [X] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing tests pass locally with my changes
- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
