### PR TITLE
Configure reference frame for multi-frame video clips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Configure reference frame for multi-frame video clips (<https://github.com/openvinotoolkit/anomalib/pull/1023>)
 - Bump OpenVINO version to `2022.3.0` (<https://github.com/openvinotoolkit/anomalib/pull/932>)
 - Remove the dependecy on a specific `torchvision` and `torchmetrics` packages.
 - Bump PyTorch Lightning version to v.1.9.\* (<https://github.com/openvinotoolkit/anomalib/pull/870>)

--- a/src/anomalib/data/base/video.py
+++ b/src/anomalib/data/base/video.py
@@ -38,6 +38,7 @@ class AnomalibVideoDataset(AnomalibDataset, ABC):
         transform (A.Compose): Albumentations Compose object describing the transforms that are applied to the inputs.
         clip_length_in_frames (int): Number of video frames in each clip.
         frames_between_clips (int): Number of frames between each consecutive video clip.
+        target_frame (VideoTargetFrame): Specifies the target frame in the video clip, used for ground truth retrieval
     """
 
     def __init__(

--- a/src/anomalib/post_processing/visualizer.py
+++ b/src/anomalib/post_processing/visualizer.py
@@ -88,11 +88,13 @@ class Visualizer:
         Returns:
             Generator that yields a display-ready visualization for each image.
         """
-        batch_size, height, width, _num_channels = batch["original_image"].size()
+        batch_size = batch["image"].shape[0]
         for i in range(batch_size):
             if "image_path" in batch:
+                height, width = batch["image"].shape[-2:]
                 image = read_image(path=batch["image_path"][i], image_size=(height, width))
             elif "video_path" in batch:
+                _, height, width, _ = batch["original_image"].shape
                 image = batch["original_image"][i].squeeze().numpy()
                 image = cv2.resize(image, dsize=(width, height), interpolation=cv2.INTER_AREA)
             else:

--- a/src/anomalib/post_processing/visualizer.py
+++ b/src/anomalib/post_processing/visualizer.py
@@ -88,7 +88,7 @@ class Visualizer:
         Returns:
             Generator that yields a display-ready visualization for each image.
         """
-        batch_size, _num_channels, height, width = batch["image"].size()
+        batch_size, height, width, _num_channels = batch["original_image"].size()
         for i in range(batch_size):
             if "image_path" in batch:
                 image = read_image(path=batch["image_path"][i], image_size=(height, width))

--- a/src/anomalib/post_processing/visualizer.py
+++ b/src/anomalib/post_processing/visualizer.py
@@ -94,7 +94,7 @@ class Visualizer:
                 height, width = batch["image"].shape[-2:]
                 image = read_image(path=batch["image_path"][i], image_size=(height, width))
             elif "video_path" in batch:
-                _, height, width, _ = batch["original_image"].shape
+                height, width = batch["original_image"].shape[1:3]
                 image = batch["original_image"][i].squeeze().numpy()
                 image = cv2.resize(image, dsize=(width, height), interpolation=cv2.INTER_AREA)
             else:

--- a/tests/pre_merge/datasets/test_video.py
+++ b/tests/pre_merge/datasets/test_video.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from anomalib.data import TaskType
+from anomalib.data.base.video import VideoTargetFrame
 from anomalib.data.ucsd_ped import (
     UCSDpedClipsIndexer,
     UCSDpedDataset,
@@ -80,3 +81,19 @@ class TestVideoDataset:
         item = next(iter(ucsd_dataset))
         # confirm that all the required keys are there
         assert set(item.keys()) == set(required_keys)
+
+    @pytest.mark.parametrize("split", [Split.TEST])
+    def test_target_frame(self, ucsd_dataset):
+        ucsd_dataset.target_frame = VideoTargetFrame.ALL
+        all_frames_item = ucsd_dataset[0]
+        ucsd_dataset.target_frame = VideoTargetFrame.FIRST
+        first_frame_item = ucsd_dataset[0]
+        ucsd_dataset.target_frame = VideoTargetFrame.LAST
+        last_frame_item = ucsd_dataset[0]
+        ucsd_dataset.target_frame = VideoTargetFrame.MID
+        mid_frame_item = ucsd_dataset[0]
+
+        # check if the correct GT frame is retrieved
+        assert first_frame_item["frames"] == all_frames_item["frames"][0]
+        assert last_frame_item["frames"] == all_frames_item["frames"][-1]
+        assert mid_frame_item["frames"] == all_frames_item["frames"][int(len(all_frames_item["frames"]) / 2)]


### PR DESCRIPTION
# Description

- In multi-frame video pipelines, we need to set which frame acts as the reference frame, meaning the ground truth information of that frame will be used to represent the (multi-frame) video clip.
- This PR makes this configurable from the config. The user may elect to take the GT info from the first frame, last frame, mid frame or all frames combined.

## Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
