### PR TITLE
[Bug: 865] datamodule.setup() assertion failed

### DIFF
--- a/notebooks/000_getting_started/001_getting_started.ipynb
+++ b/notebooks/000_getting_started/001_getting_started.ipynb
@@ -229,8 +229,8 @@
    ],
    "source": [
     "datamodule = get_datamodule(config)\n",
-    "datamodule.setup()  # Downloads the dataset if it's not in the specified `root` directory\n",
-    "datamodule.prepare_data()  # Create train/val/test/prediction sets.\n",
+    "datamodule.prepare_data()  # Downloads the dataset if it's not in the specified `root` directory\n",
+    "datamodule.setup()  # Create train/val/test/prediction sets.\n",
     "\n",
     "i, data = next(enumerate(datamodule.val_dataloader()))\n",
     "print(data.keys())"

--- a/src/anomalib/models/components/layers/sspcab.py
+++ b/src/anomalib/models/components/layers/sspcab.py
@@ -57,8 +57,8 @@ class SSPCAB(nn.Module):
         super().__init__()
 
         self.pad = kernel_size + dilation
-        self.crop = 2 * (kernel_size + dilation)
-
+        self.crop = kernel_size + 2 * dilation + 1
+        
         self.masked_conv1 = nn.Conv2d(in_channels=in_channels, out_channels=in_channels, kernel_size=kernel_size)
         self.masked_conv2 = nn.Conv2d(in_channels=in_channels, out_channels=in_channels, kernel_size=kernel_size)
         self.masked_conv3 = nn.Conv2d(in_channels=in_channels, out_channels=in_channels, kernel_size=kernel_size)

--- a/src/anomalib/models/components/layers/sspcab.py
+++ b/src/anomalib/models/components/layers/sspcab.py
@@ -58,7 +58,7 @@ class SSPCAB(nn.Module):
 
         self.pad = kernel_size + dilation
         self.crop = kernel_size + 2 * dilation + 1
-        
+
         self.masked_conv1 = nn.Conv2d(in_channels=in_channels, out_channels=in_channels, kernel_size=kernel_size)
         self.masked_conv2 = nn.Conv2d(in_channels=in_channels, out_channels=in_channels, kernel_size=kernel_size)
         self.masked_conv3 = nn.Conv2d(in_channels=in_channels, out_channels=in_channels, kernel_size=kernel_size)


### PR DESCRIPTION
[Bug: 865] datamodule.setup() assertion failed

This fix download the dataset first before splitting the train/val/test sets.

- Fixes #865

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
