### PR TITLE
Fix logger message for test_split_ratio

### DIFF
--- a/src/anomalib/data/base/datamodule.py
+++ b/src/anomalib/data/base/datamodule.py
@@ -130,7 +130,7 @@ class AnomalibDataModule(LightningDataModule, ABC):
             # when the user did not provide any normal images for testing, we sample some from the training set,
             # except when the user explicitly requested no test splitting.
             logger.info(
-                "No normal test images found. Sampling from training set using a split ratio of %d",
+                "No normal test images found. Sampling from training set using a split ratio of %0.2f",
                 self.test_split_ratio,
             )
             if self.test_split_ratio is not None:


### PR DESCRIPTION
# Description

Fixes `test_split_ratio` logging values of 0 for the ratio, which is a percentage. 

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
