### PR TITLE
Modify codecov upload

### DIFF
--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -61,5 +61,5 @@ jobs:
           then
             ./codecov -t ${{ secrets.CODECOV_TOKEN }} --sha $COMMIT_ID -U $HTTP_PROXY -f .tox/coverage.xml
           else
-            ./codecov --sha $COMMIT_ID -U $HTTP_PROXY -f .tox/coverage.xml
+            ./codecov --sha $COMMIT_ID -r openvinotoolkit/anomalib -U $HTTP_PROXY -f .tox/coverage.xml
           fi

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -52,8 +52,14 @@ jobs:
           else
             COMMIT_ID=${{ github.sha }}
           fi
+          # Only pass token if it exists
           # current version of codecov-action does not support uploading reports through the proxy
           # so we use the latest version of codecov uploader binary
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           chmod +x codecov
-          ./codecov -t ${{ secrets.CODECOV_TOKEN }} --sha $COMMIT_ID -Z true -U $HTTP_PROXY -f .tox/coverage.xml
+          if [ -n "${{ secrets.CODECOV_TOKEN }}" ]
+          then
+            ./codecov -t ${{ secrets.CODECOV_TOKEN }} --sha $COMMIT_ID -U $HTTP_PROXY -f .tox/coverage.xml
+          else
+            ./codecov --sha $COMMIT_ID -U $HTTP_PROXY -f .tox/coverage.xml
+          fi


### PR DESCRIPTION
# Description

- Removed the `-Z` flag as it fails the CI if codecov upload fails
- Don't pass token if it is not passed to the action.
