### PR TITLE
Pass codedov token from environment

### DIFF
--- a/.ci/README.md
+++ b/.ci/README.md
@@ -52,10 +52,10 @@
 
 1. Now the container is ready. Type `exit` to leave the container.
 
-1. Start github actions runner in detached mode in the container and set the
-   the anomalib dataset environment variables.
+1. Start github actions runner in detached mode in the container and set the anomalib dataset and codecov environment
+   variables. The codecov token in the environment variable allows coverage report uploading from the forks.
 
    ```bash
    sudo docker exec -d anomalib-ci-container /bin/bash -c \
-   "export ANOMALIB_DATASET_PATH=/home/user/datasets && /home/user/actions-runner/run.sh"
+   "export ANOMALIB_DATASET_PATH=/home/user/datasets;export CODECOV_TOKEN=XXX && /home/user/actions-runner/run.sh"
    ```

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -58,24 +58,21 @@ jobs:
         run: touch coverage.xml
       - name: Upload coverage report
         run: |
-          # # If the workflow is triggered from PR then it gets the commit id from the PR.
-          # # else it uses the commit id of the latest commit. This is because the commit
-          # # of the checked-out branch/commit does not exist in the tree as it is grafted.
-          # if [ -n "${{ github.event.pull_request.head.sha }}" ]
-          # then
-          #   COMMIT_ID=${{ github.event.pull_request.head.sha }}
-          # else
-          #   COMMIT_ID=${{ github.sha }}
-          # fi
-          # # Only pass token if it exists
-          # # current version of codecov-action does not support uploading reports through the proxy
-          # # so we use the latest version of codecov uploader binary
+          # If the workflow is triggered from PR then it gets the commit id from the PR.
+          # else it uses the commit id of the latest commit. This is because the commit
+          # of the checked-out branch/commit does not exist in the tree as it is grafted.
+          if [ -n "${{ github.event.pull_request.head.sha }}" ]
+          then
+            COMMIT_ID=${{ github.event.pull_request.head.sha }}
+          else
+            COMMIT_ID=${{ github.sha }}
+          fi
+          # Pass token from secrets if available. Otherwise it takes it from the environment variable of the CI
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           chmod +x codecov
-          # if [ -n "${{ secrets.CODECOV_TOKEN }}" ]
-          # then
-          #   ./codecov -t ${{ secrets.CODECOV_TOKEN }} --sha $COMMIT_ID -U $HTTP_PROXY -f .tox/coverage.xml
-          # else
-          #   ./codecov --sha $COMMIT_ID -r openvinotoolkit/anomalib -U $HTTP_PROXY -f .tox/coverage.xml
-          # fi
-          ./codecov -t "${CODECOV_TOKEN}"  --sha $COMMIT_ID -r openvinotoolkit/anomalib -U $HTTP_PROXY -f .tox/coverage.xml
+          if [ -n "${{ secrets.CODECOV_TOKEN }}" ]
+          then
+            ./codecov -t ${{ secrets.CODECOV_TOKEN }} --sha $COMMIT_ID -U $HTTP_PROXY -f .tox/coverage.xml
+          else
+            ./codecov -t "${CODECOV_TOKEN}"  --sha $COMMIT_ID -U $HTTP_PROXY -f coverage.xml
+          fi

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -57,10 +57,25 @@ jobs:
         # run: tox -e pre-merge-${{ matrix.tox-env }}
         run: touch coverage.xml
       - name: Upload coverage report
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml
-          upstream_proxy: http://proxy-mu.intel.com:911
-          fail_ci_if_error: true
-          verbose: true
+        run: |
+          # # If the workflow is triggered from PR then it gets the commit id from the PR.
+          # # else it uses the commit id of the latest commit. This is because the commit
+          # # of the checked-out branch/commit does not exist in the tree as it is grafted.
+          # if [ -n "${{ github.event.pull_request.head.sha }}" ]
+          # then
+          #   COMMIT_ID=${{ github.event.pull_request.head.sha }}
+          # else
+          #   COMMIT_ID=${{ github.sha }}
+          # fi
+          # # Only pass token if it exists
+          # # current version of codecov-action does not support uploading reports through the proxy
+          # # so we use the latest version of codecov uploader binary
+          # curl -Os https://uploader.codecov.io/latest/linux/codecov
+          # chmod +x codecov
+          # if [ -n "${{ secrets.CODECOV_TOKEN }}" ]
+          # then
+          #   ./codecov -t ${{ secrets.CODECOV_TOKEN }} --sha $COMMIT_ID -U $HTTP_PROXY -f .tox/coverage.xml
+          # else
+          #   ./codecov --sha $COMMIT_ID -r openvinotoolkit/anomalib -U $HTTP_PROXY -f .tox/coverage.xml
+          # fi
+          ./codecov -t "${CODECOV_TOKEN}"  --sha $COMMIT_ID -r openvinotoolkit/anomalib -U $HTTP_PROXY -f .tox/coverage.xml

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -70,8 +70,8 @@ jobs:
           # # Only pass token if it exists
           # # current version of codecov-action does not support uploading reports through the proxy
           # # so we use the latest version of codecov uploader binary
-          # curl -Os https://uploader.codecov.io/latest/linux/codecov
-          # chmod +x codecov
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
           # if [ -n "${{ secrets.CODECOV_TOKEN }}" ]
           # then
           #   ./codecov -t ${{ secrets.CODECOV_TOKEN }} --sha $COMMIT_ID -U $HTTP_PROXY -f .tox/coverage.xml

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -61,6 +61,6 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
-          upstream_proxy: http://proxy-mu.intel.com:912
+          upstream_proxy: http://proxy-mu.intel.com:911
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -57,21 +57,10 @@ jobs:
         # run: tox -e pre-merge-${{ matrix.tox-env }}
         run: touch .tox/coverage.xml
       - name: Upload coverage report
+        uses: codecov/codecov-action@v3
         with:
-          codecov_token: ${{ secrets.CODECOV_TOKEN }}
-        run: |
-          # If the workflow is triggered from PR then it gets the commit id from the PR.
-          # else it uses the commit id of the latest commit. This is because the commit
-          # of the checked-out branch/commit does not exist in the tree as it is grafted.
-          if [ -n "${{ github.event.pull_request.head.sha }}" ]
-          then
-            COMMIT_ID=${{ github.event.pull_request.head.sha }}
-          else
-            COMMIT_ID=${{ github.sha }}
-          fi
-          # Only pass token if it exists
-          # current version of codecov-action does not support uploading reports through the proxy
-          # so we use the latest version of codecov uploader binary
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          chmod +x codecov
-          ./codecov -t "$codecov_token" --sha $COMMIT_ID -U $HTTP_PROXY -f .tox/coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: .tox/coverage.xml
+          upstream_proxy: http://proxy-mu.intel.com:912
+          fail_ci_if_error: true
+          verbose: true

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -17,22 +17,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  Code-Quality-Checks:
-    runs-on: [self-hosted, linux, x64]
-    steps:
-      - name: CHECKOUT REPOSITORY
-        uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-      - name: Install Tox
-        run: pip install tox
-      - name: Code quality checks
-        run: tox -e pre-commit
+  # Code-Quality-Checks:
+  #   runs-on: [self-hosted, linux, x64]
+  #   steps:
+  #     - name: CHECKOUT REPOSITORY
+  #       uses: actions/checkout@v2
+  #     - name: Set up Python
+  #       uses: actions/setup-python@v4
+  #       with:
+  #         python-version: "3.10"
+  #     - name: Install Tox
+  #       run: pip install tox
+  #     - name: Code quality checks
+  #       run: tox -e pre-commit
   Pre-Merge-Checks:
     runs-on: [self-hosted, linux, x64]
-    needs: Code-Quality-Checks
+    # needs: Code-Quality-Checks
     if: github.event.pull_request.draft == false
     strategy:
       max-parallel: 1
@@ -55,12 +55,12 @@ jobs:
           ln -s $ANOMALIB_DATASET_PATH ./notebooks/datasets
       - name: Coverage
         # run: tox -e pre-merge-${{ matrix.tox-env }}
-        run: touch .tox/coverage.xml
+        run: touch coverage.xml
       - name: Upload coverage report
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: .tox/coverage.xml
+          files: coverage.xml
           upstream_proxy: http://proxy-mu.intel.com:912
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -54,8 +54,11 @@ jobs:
           ln -s $ANOMALIB_DATASET_PATH ./datasets
           ln -s $ANOMALIB_DATASET_PATH ./notebooks/datasets
       - name: Coverage
-        run: tox -e pre-merge-${{ matrix.tox-env }}
+        # run: tox -e pre-merge-${{ matrix.tox-env }}
+        run: touch .tox/coverage.xml
       - name: Upload coverage report
+        with:
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
         run: |
           # If the workflow is triggered from PR then it gets the commit id from the PR.
           # else it uses the commit id of the latest commit. This is because the commit
@@ -71,9 +74,4 @@ jobs:
           # so we use the latest version of codecov uploader binary
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           chmod +x codecov
-          if [ -n "${{ secrets.CODECOV_TOKEN }}" ]
-          then
-            ./codecov -t ${{ secrets.CODECOV_TOKEN }} --sha $COMMIT_ID -U $HTTP_PROXY -f .tox/coverage.xml
-          else
-            ./codecov --sha $COMMIT_ID -r openvinotoolkit/anomalib -U $HTTP_PROXY -f .tox/coverage.xml
-          fi
+          ./codecov -t "$codecov_token" --sha $COMMIT_ID -U $HTTP_PROXY -f .tox/coverage.xml

--- a/.github/workflows/pre_merge.yml
+++ b/.github/workflows/pre_merge.yml
@@ -17,22 +17,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Code-Quality-Checks:
-  #   runs-on: [self-hosted, linux, x64]
-  #   steps:
-  #     - name: CHECKOUT REPOSITORY
-  #       uses: actions/checkout@v2
-  #     - name: Set up Python
-  #       uses: actions/setup-python@v4
-  #       with:
-  #         python-version: "3.10"
-  #     - name: Install Tox
-  #       run: pip install tox
-  #     - name: Code quality checks
-  #       run: tox -e pre-commit
+  Code-Quality-Checks:
+    runs-on: [self-hosted, linux, x64]
+    steps:
+      - name: CHECKOUT REPOSITORY
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install Tox
+        run: pip install tox
+      - name: Code quality checks
+        run: tox -e pre-commit
   Pre-Merge-Checks:
     runs-on: [self-hosted, linux, x64]
-    # needs: Code-Quality-Checks
+    needs: Code-Quality-Checks
     if: github.event.pull_request.draft == false
     strategy:
       max-parallel: 1
@@ -54,8 +54,7 @@ jobs:
           ln -s $ANOMALIB_DATASET_PATH ./datasets
           ln -s $ANOMALIB_DATASET_PATH ./notebooks/datasets
       - name: Coverage
-        # run: tox -e pre-merge-${{ matrix.tox-env }}
-        run: touch coverage.xml
+        run: tox -e pre-merge-${{ matrix.tox-env }}
       - name: Upload coverage report
         run: |
           # If the workflow is triggered from PR then it gets the commit id from the PR.
@@ -74,5 +73,5 @@ jobs:
           then
             ./codecov -t ${{ secrets.CODECOV_TOKEN }} --sha $COMMIT_ID -U $HTTP_PROXY -f .tox/coverage.xml
           else
-            ./codecov -t "${CODECOV_TOKEN}"  --sha $COMMIT_ID -U $HTTP_PROXY -f coverage.xml
+            ./codecov -t "${CODECOV_TOKEN}"  --sha $COMMIT_ID -U $HTTP_PROXY -f .tox/coverage.xml
           fi


### PR DESCRIPTION
# Description

- Workaround to accessing secrets from fork is to use environment variable in the CI. After updating the CI, this PR uses the environment variable as a fallback

## Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
