### PR TITLE
(Minor change) Added the tracer_kwargs to the TorchFXFeatureExtractor class

### DIFF
--- a/src/anomalib/models/components/feature_extractors/torchfx.py
+++ b/src/anomalib/models/components/feature_extractors/torchfx.py
@@ -91,6 +91,7 @@ class TorchFXFeatureExtractor(nn.Module):
         return_nodes: list[str],
         weights: str | WeightsEnum | None = None,
         requires_grad: bool = False,
+        tracer_kwargs: dict | None = None,
     ):
         super().__init__()
         if isinstance(backbone, dict):
@@ -102,7 +103,9 @@ class TorchFXFeatureExtractor(nn.Module):
                 f"backbone needs to be of type str | BackboneParams | dict | nn.Module, but was type {type(backbone)}"
             )
 
-        self.feature_extractor = self.initialize_feature_extractor(backbone, return_nodes, weights, requires_grad)
+        self.feature_extractor = self.initialize_feature_extractor(
+            backbone, return_nodes, weights, requires_grad, tracer_kwargs
+        )
 
     def initialize_feature_extractor(
         self,
@@ -110,6 +113,7 @@ class TorchFXFeatureExtractor(nn.Module):
         return_nodes: list[str],
         weights: str | WeightsEnum | None = None,
         requires_grad: bool = False,
+        tracer_kwargs: dict | None = None,
     ) -> GraphModule:
         """Extract features from a CNN.
 
@@ -125,6 +129,9 @@ class TorchFXFeatureExtractor(nn.Module):
                 path for custom models.
             requires_grad (bool): Models like ``stfpm`` use the feature extractor for training. In such cases we should
                 set ``requires_grad`` to ``True``. Default is ``False``.
+            tracer_kwargs (dict | None): a dictionary of keyword arguments for NodePathTracer (which passes them onto
+                it's parent class torch.fx.Tracer). Can be used to allow not tracing through a list of problematic
+                modules, by passing a list of `leaf_modules` as one of the `tracer_kwargs`.
 
         Returns:
             Feature Extractor based on TorchFX.
@@ -148,7 +155,7 @@ class TorchFXFeatureExtractor(nn.Module):
                         model_weights = model_weights["state_dict"]
                     backbone_model.load_state_dict(model_weights)
 
-        feature_extractor = create_feature_extractor(backbone_model, return_nodes)
+        feature_extractor = create_feature_extractor(backbone_model, return_nodes, tracer_kwargs=tracer_kwargs)
 
         if not requires_grad:
             feature_extractor.eval()

--- a/src/anomalib/models/components/feature_extractors/torchfx.py
+++ b/src/anomalib/models/components/feature_extractors/torchfx.py
@@ -39,6 +39,9 @@ class TorchFXFeatureExtractor(nn.Module):
             path for custom models.
         requires_grad (bool): Models like ``stfpm`` use the feature extractor for training. In such cases we should
             set ``requires_grad`` to ``True``. Default is ``False``.
+        tracer_kwargs (dict | None): a dictionary of keyword arguments for NodePathTracer (which passes them onto
+            it's parent class torch.fx.Tracer). Can be used to allow not tracing through a list of problematic
+            modules, by passing a list of `leaf_modules` as one of the `tracer_kwargs`.
 
     Example:
         With torchvision models:


### PR DESCRIPTION
# Description
Currently the usage of specific feature extractors with custom layers, some of which might be problematic to the torch tracer is not possible (check [example in the pytorch documentation](https://pytorch.org/vision/main/generated/torchvision.models.feature_extraction.create_feature_extractor.html#create-feature-extractor)). For this to work, I added the tracer_kwargs parameter to the custom "TorchFXFeatureExtractor" class. 

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
