### PR TITLE
Enable training with only normal images for MVTec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Enable training with only normal images for MVTecv in https://github.com/openvinotoolkit/anomalib/pull/1241
 - Improve default settings of EfficientAD
 
 ### Deprecated

--- a/src/anomalib/data/mvtec.py
+++ b/src/anomalib/data/mvtec.py
@@ -153,13 +153,14 @@ def make_mvtec_dataset(
     ] = mask_samples.image_path.values
 
     # assert that the right mask files are associated with the right test images
-    assert (
-        samples.loc[samples.label_index == LabelName.ABNORMAL]
-        .apply(lambda x: Path(x.image_path).stem in Path(x.mask_path).stem, axis=1)
-        .all()
-    ), "Mismatch between anomalous images and ground truth masks. Make sure the mask files in 'ground_truth' \
-              folder follow the same naming convention as the anomalous images in the dataset (e.g. image: '000.png', \
-              mask: '000.png' or '000_mask.png')."
+    if len(samples.loc[samples.label_index == LabelName.ABNORMAL]):
+        assert (
+            samples.loc[samples.label_index == LabelName.ABNORMAL]
+            .apply(lambda x: Path(x.image_path).stem in Path(x.mask_path).stem, axis=1)
+            .all()
+        ), "Mismatch between anomalous images and ground truth masks. Make sure the mask files in 'ground_truth' \
+                folder follow the same naming convention as the anomalous images in the dataset (e.g. image: \
+                '000.png', mask: '000.png' or '000_mask.png')."
 
     if split:
         samples = samples[samples.split == split].reset_index(drop=True)


### PR DESCRIPTION
# Description

- Ignore the image-path mask-path check in the MVTec sample collection when no anomalous samples are available. This ensures that the dataset and datamodule can be created when only normal samples are available in the directory structure.

- Fixes https://github.com/openvinotoolkit/anomalib/issues/1238

## Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
