### PR TITLE
Wandb unwatch method belongs to experiment, not logger

### DIFF
--- a/src/anomalib/utils/callbacks/graph.py
+++ b/src/anomalib/utils/callbacks/graph.py
@@ -43,4 +43,4 @@ class GraphLogger(Callback):
             if isinstance(logger, (AnomalibCometLogger, AnomalibTensorBoardLogger)):
                 logger.log_graph(pl_module, input_array=torch.ones((1, 3, 256, 256)))
             elif isinstance(logger, AnomalibWandbLogger):
-                logger.unwatch(pl_module)  # type: ignore
+                logger.experiment.unwatch(pl_module)  # type: ignore


### PR DESCRIPTION
# Description

Fixes #994 

## Changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the [pre-commit style and check guidelines](https://github.com/openvinotoolkit/anomalib/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings