### PR TITLE
[Custom Trainer] Remove future annotations

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -69,7 +69,7 @@ body:
       value: |
         OS information:
         - OS: [e.g. Ubuntu 20.04]
-        - Python version: [e.g. 3.8.10]
+        - Python version: [e.g. 3.10.0]
         - Anomalib version: [e.g. 0.3.6]
         - PyTorch version: [e.g. 1.9.0]
         - CUDA/cuDNN version: [e.g. 11.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Support only Python 3.10 and greater in https://github.com/openvinotoolkit/anomalib/pull/1299
 - Enable training with only normal images for MVTecv in https://github.com/openvinotoolkit/anomalib/pull/1241
 - Improve default settings of EfficientAD
 

--- a/docs/source/getting_started/installation/environment_managers/conda.rst
+++ b/docs/source/getting_started/installation/environment_managers/conda.rst
@@ -21,10 +21,10 @@ Step 1: Clone the Repository
 
    git clone https://github.com/openvinotoolkit/anomalib.git
 
-Step 2: Create a Conda Environment with Python 3.8
+Step 2: Create a Conda Environment with Python 3.10
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In this tutorial, we use Python 3.8. If you want to use a higher version, that is also possible.
+In this tutorial, we use Python 3.10. If you want to use a higher version, that is also possible.
 
 .. code:: bash
 

--- a/docs/source/getting_started/installation/operating_systems/linux/ubuntu.rst
+++ b/docs/source/getting_started/installation/operating_systems/linux/ubuntu.rst
@@ -84,8 +84,7 @@ Troubleshooting
 -  The system default version of Python on Ubuntu 20.04 is Python 3.8,
    on Ubuntu 22.04 - 3.10. If you also installed other versions of
    Python, it is recommended to use the full path the to system default
-   Python: ``/usr/bin/python3.8 -m venv anomalib_env`` on Ubuntu 20,
-   ``/usr/bin/python3.10 -m venv anomalib_env`` on Ubuntu 22.
+   Python: ``/usr/bin/python3.10 -m venv anomalib_env`` on Ubuntu 22.
 
 -  If you use Anaconda or Miniconda, see the :ref:`conda` installation instructions.
 

--- a/docs/source/getting_started/installation/operating_systems/windows.rst
+++ b/docs/source/getting_started/installation/operating_systems/windows.rst
@@ -11,10 +11,9 @@ Windows
 .. warning::
     The version of Python that is available in the Microsoft Store is not recommended. It may require installation of additional packages to work well with OpenVINO and the notebooks.
 
--  Download a Python installer from python.org. Choose Python 3.8,
-   3.9 or 3.10 and make sure to pick a 64 bit version. For example, this
-   3.8 installer:
-   https://www.python.org/ftp/python/3.8.8/python-3.8.8-amd64.exe
+-  Download a Python installer from python.org. Choose Python 3.10
+   and make sure to pick a 64 bit version. For example, this 3.10 installer:
+   https://www.python.org/ftp/python/3.10.0/python-3.10.0-embed-amd64.zip
 -  Double click on the installer to run it, and follow the steps in the
    installer. **Check the box to add Python to your PATH**, and to
    install ``py``. At the end of the installer, there is an option to
@@ -28,7 +27,7 @@ Windows
 -  Double click on the installer to run it, and follow the steps in the
    installer.
 
-3. Install C++ Redistributable (For Python 3.8)
+3. Install C++ Redistributable (For Python 3.10)
 -----------------------------------------------
 
 -  Download `Microsoft Visual C++
@@ -83,9 +82,9 @@ dependencies.
 Troubleshooting
 ---------------
 
--  If you have installed multiple versions of Python, use ``py -3.8``
+-  If you have installed multiple versions of Python, use ``py -3.10``
    when creating your virtual environment to specify a supported version
-   (in this case 3.7).
+   (in this case 3.10).
 
 -  If you use Anaconda, you may need to add OpenVINO to your Windows
    PATH. See the

--- a/notebooks/000_getting_started/001_getting_started.ipynb
+++ b/notebooks/000_getting_started/001_getting_started.ipynb
@@ -88,8 +88,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from __future__ import annotations\n",
-    "\n",
     "import os\n",
     "from pathlib import Path\n",
     "from typing import Any\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,8 @@ line-length = 120
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-# Assume Python 3.8.
-target-version = "py38"
+# Assume Python 3.10.
+target-version = "py310"
 
 # Allow imports relative to the "src" and "tests" directories.
 src = ["src", "tests"]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path

--- a/src/anomalib/config/config.py
+++ b/src/anomalib/config/config.py
@@ -6,7 +6,6 @@
 # TODO: This would require a new design.
 # TODO: https://jira.devtools.intel.com/browse/IAAALD-149
 
-from __future__ import annotations
 
 import time
 import warnings

--- a/src/anomalib/data/__init__.py
+++ b/src/anomalib/data/__init__.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 from enum import Enum

--- a/src/anomalib/data/avenue.py
+++ b/src/anomalib/data/avenue.py
@@ -13,7 +13,6 @@ Reference:
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 import math

--- a/src/anomalib/data/base/datamodule.py
+++ b/src/anomalib/data/base/datamodule.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 from abc import ABC
@@ -16,12 +15,7 @@ from torch.utils.data.dataloader import DataLoader, default_collate
 
 from anomalib.data.base.dataset import AnomalibDataset
 from anomalib.data.synthetic import SyntheticAnomalyDataset
-from anomalib.data.utils import (
-    TestSplitMode,
-    ValSplitMode,
-    random_split,
-    split_by_label,
-)
+from anomalib.data.utils import TestSplitMode, ValSplitMode, random_split, split_by_label
 
 logger = logging.getLogger(__name__)
 

--- a/src/anomalib/data/base/dataset.py
+++ b/src/anomalib/data/base/dataset.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import copy
 import logging
@@ -51,7 +50,7 @@ class AnomalibDataset(Dataset, ABC):
         """Get length of the dataset."""
         return len(self.samples)
 
-    def subsample(self, indices: Sequence[int], inplace: bool = False) -> AnomalibDataset:
+    def subsample(self, indices: Sequence[int], inplace: bool = False) -> "AnomalibDataset":
         """Subsamples the dataset at the provided indices.
 
         Args:
@@ -147,7 +146,7 @@ class AnomalibDataset(Dataset, ABC):
 
         return item
 
-    def __add__(self, other_dataset: AnomalibDataset) -> AnomalibDataset:
+    def __add__(self, other_dataset: "AnomalibDataset") -> "AnomalibDataset":
         """Concatenate this dataset with another dataset."""
         assert isinstance(other_dataset, self.__class__), "Cannot concatenate datasets that are not of the same type."
         assert self.is_setup, "Cannot concatenate uninitialized datasets. Call setup first."

--- a/src/anomalib/data/base/depth.py
+++ b/src/anomalib/data/base/depth.py
@@ -1,6 +1,5 @@
 """Base Depth Dataset."""
 
-from __future__ import annotations
 
 from abc import ABC
 

--- a/src/anomalib/data/base/video.py
+++ b/src/anomalib/data/base/video.py
@@ -1,6 +1,5 @@
 """Base Video Dataset."""
 
-from __future__ import annotations
 
 from abc import ABC
 from enum import Enum

--- a/src/anomalib/data/btech.py
+++ b/src/anomalib/data/btech.py
@@ -9,7 +9,6 @@ extracts the dataset and create PyTorch data objects.
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 import shutil

--- a/src/anomalib/data/folder.py
+++ b/src/anomalib/data/folder.py
@@ -5,7 +5,6 @@ This script creates a custom dataset from a folder.
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from pathlib import Path
 from typing import Sequence

--- a/src/anomalib/data/folder_3d.py
+++ b/src/anomalib/data/folder_3d.py
@@ -6,7 +6,6 @@ This script creates a custom dataset from a folder.
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from pathlib import Path
 

--- a/src/anomalib/data/inference.py
+++ b/src/anomalib/data/inference.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from pathlib import Path
 from typing import Any

--- a/src/anomalib/data/kolektor.py
+++ b/src/anomalib/data/kolektor.py
@@ -17,8 +17,6 @@ Reference:
 """
 
 
-from __future__ import annotations
-
 import logging
 from pathlib import Path
 

--- a/src/anomalib/data/mvtec.py
+++ b/src/anomalib/data/mvtec.py
@@ -23,7 +23,6 @@ Reference:
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 from pathlib import Path

--- a/src/anomalib/data/mvtec_3d.py
+++ b/src/anomalib/data/mvtec_3d.py
@@ -20,7 +20,6 @@ Reference:
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 from pathlib import Path

--- a/src/anomalib/data/shanghaitech.py
+++ b/src/anomalib/data/shanghaitech.py
@@ -13,7 +13,6 @@ Reference:
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 from pathlib import Path

--- a/src/anomalib/data/synthetic.py
+++ b/src/anomalib/data/synthetic.py
@@ -6,7 +6,6 @@ This dataset can be used when there is a lack of real anomalous data.
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 import math
@@ -131,7 +130,7 @@ class SyntheticAnomalyDataset(AnomalibDataset):
         self.setup()
 
     @classmethod
-    def from_dataset(cls, dataset: AnomalibDataset) -> SyntheticAnomalyDataset:
+    def from_dataset(cls, dataset: AnomalibDataset) -> "SyntheticAnomalyDataset":
         """Create a synthetic anomaly dataset from an existing dataset of normal images.
 
         Args:
@@ -140,7 +139,7 @@ class SyntheticAnomalyDataset(AnomalibDataset):
         """
         return cls(task=dataset.task, transform=dataset.transform, source_samples=dataset.samples)
 
-    def __copy__(self) -> SyntheticAnomalyDataset:
+    def __copy__(self) -> "SyntheticAnomalyDataset":
         """Returns a shallow copy of the dataset object and prevents cleanup when original object is deleted."""
         cls = self.__class__
         new = cls.__new__(cls)
@@ -148,7 +147,7 @@ class SyntheticAnomalyDataset(AnomalibDataset):
         self._cleanup = False
         return new
 
-    def __deepcopy__(self, _memo: dict) -> SyntheticAnomalyDataset:
+    def __deepcopy__(self, _memo: dict) -> "SyntheticAnomalyDataset":
         """Returns a deep copy of the dataset object and prevents cleanup when original object is deleted."""
         cls = self.__class__
         new = cls.__new__(cls)

--- a/src/anomalib/data/ucsd_ped.py
+++ b/src/anomalib/data/ucsd_ped.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 from pathlib import Path

--- a/src/anomalib/data/utils/augmenter.py
+++ b/src/anomalib/data/utils/augmenter.py
@@ -10,8 +10,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from __future__ import annotations
-
 import glob
 import math
 import random

--- a/src/anomalib/data/utils/boxes.py
+++ b/src/anomalib/data/utils/boxes.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import torch
 from torch import Tensor

--- a/src/anomalib/data/utils/download.py
+++ b/src/anomalib/data/utils/download.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import hashlib
 import io

--- a/src/anomalib/data/utils/generators/perlin.py
+++ b/src/anomalib/data/utils/generators/perlin.py
@@ -11,7 +11,6 @@
 
 # pylint: disable=invalid-name
 
-from __future__ import annotations
 
 import math
 

--- a/src/anomalib/data/utils/image.py
+++ b/src/anomalib/data/utils/image.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import math
 import warnings

--- a/src/anomalib/data/utils/path.py
+++ b/src/anomalib/data/utils/path.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from enum import Enum
 from pathlib import Path

--- a/src/anomalib/data/utils/split.py
+++ b/src/anomalib/data/utils/split.py
@@ -11,7 +11,6 @@ These function are useful
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import math
 import warnings

--- a/src/anomalib/data/utils/transform.py
+++ b/src/anomalib/data/utils/transform.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 from enum import Enum

--- a/src/anomalib/data/utils/video.py
+++ b/src/anomalib/data/utils/video.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import warnings
 from abc import ABC, abstractmethod

--- a/src/anomalib/data/visa.py
+++ b/src/anomalib/data/visa.py
@@ -21,7 +21,6 @@ Reference:
 # Subset splitting code adapted from https://github.com/amazon-science/spot-diff
 # Original licence: Apache-2.0
 
-from __future__ import annotations
 
 import csv
 import logging

--- a/src/anomalib/deploy/export.py
+++ b/src/anomalib/deploy/export.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import json
 import logging

--- a/src/anomalib/deploy/inferencers/base_inferencer.py
+++ b/src/anomalib/deploy/inferencers/base_inferencer.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from pathlib import Path

--- a/src/anomalib/deploy/inferencers/openvino_inferencer.py
+++ b/src/anomalib/deploy/inferencers/openvino_inferencer.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 from importlib.util import find_spec

--- a/src/anomalib/deploy/inferencers/torch_inferencer.py
+++ b/src/anomalib/deploy/inferencers/torch_inferencer.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from pathlib import Path
 from typing import Any

--- a/src/anomalib/models/__init__.py
+++ b/src/anomalib/models/__init__.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 import os

--- a/src/anomalib/models/ai_vad/density.py
+++ b/src/anomalib/models/ai_vad/density.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import Any

--- a/src/anomalib/models/ai_vad/features.py
+++ b/src/anomalib/models/ai_vad/features.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from enum import Enum
 

--- a/src/anomalib/models/ai_vad/flow.py
+++ b/src/anomalib/models/ai_vad/flow.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import torch
 import torchvision.transforms.functional as F

--- a/src/anomalib/models/ai_vad/lightning_model.py
+++ b/src/anomalib/models/ai_vad/lightning_model.py
@@ -6,7 +6,6 @@ Paper https://arxiv.org/pdf/2212.00789.pdf
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 

--- a/src/anomalib/models/ai_vad/regions.py
+++ b/src/anomalib/models/ai_vad/regions.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import torch
 from torch import Tensor, nn

--- a/src/anomalib/models/ai_vad/torch_model.py
+++ b/src/anomalib/models/ai_vad/torch_model.py
@@ -6,7 +6,6 @@ Paper https://arxiv.org/pdf/2212.00789.pdf
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import torch
 from torch import Tensor, nn

--- a/src/anomalib/models/cfa/anomaly_map.py
+++ b/src/anomalib/models/cfa/anomaly_map.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from __future__ import annotations
-
 import torch
 import torch.nn.functional as F
 from einops import rearrange

--- a/src/anomalib/models/cfa/lightning_model.py
+++ b/src/anomalib/models/cfa/lightning_model.py
@@ -8,7 +8,6 @@ Paper https://arxiv.org/abs/2206.04325
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 

--- a/src/anomalib/models/cfa/torch_model.py
+++ b/src/anomalib/models/cfa/torch_model.py
@@ -8,7 +8,6 @@ Paper https://arxiv.org/abs/2206.04325
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import torch
 import torch.nn.functional as F

--- a/src/anomalib/models/cflow/anomaly_map.py
+++ b/src/anomalib/models/cflow/anomaly_map.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from typing import List, cast
 

--- a/src/anomalib/models/cflow/lightning_model.py
+++ b/src/anomalib/models/cflow/lightning_model.py
@@ -6,7 +6,6 @@ https://arxiv.org/pdf/2107.12571v1.pdf
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import einops
 import torch

--- a/src/anomalib/models/cflow/torch_model.py
+++ b/src/anomalib/models/cflow/torch_model.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from typing import Any
 

--- a/src/anomalib/models/cflow/utils.py
+++ b/src/anomalib/models/cflow/utils.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 import math

--- a/src/anomalib/models/components/classification/kde_classifier.py
+++ b/src/anomalib/models/components/classification/kde_classifier.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 import random

--- a/src/anomalib/models/components/dimensionality_reduction/pca.py
+++ b/src/anomalib/models/components/dimensionality_reduction/pca.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import torch
 from torch import Tensor

--- a/src/anomalib/models/components/dimensionality_reduction/random_projection.py
+++ b/src/anomalib/models/components/dimensionality_reduction/random_projection.py
@@ -7,7 +7,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import numpy as np
 import torch
@@ -91,7 +90,7 @@ class SparseRandomProjection:
         denominator = (eps**2 / 2) - (eps**3 / 3)
         return (4 * np.log(n_samples) / denominator).astype(np.int64)
 
-    def fit(self, embedding: Tensor) -> SparseRandomProjection:
+    def fit(self, embedding: Tensor) -> "SparseRandomProjection":
         """Generates sparse matrix from the embedding tensor.
 
         Args:

--- a/src/anomalib/models/components/feature_extractors/timm.py
+++ b/src/anomalib/models/components/feature_extractors/timm.py
@@ -6,7 +6,6 @@ This script extracts features from a CNN network
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 import warnings

--- a/src/anomalib/models/components/feature_extractors/torchfx.py
+++ b/src/anomalib/models/components/feature_extractors/torchfx.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import importlib
 from dataclasses import dataclass, field

--- a/src/anomalib/models/components/feature_extractors/utils.py
+++ b/src/anomalib/models/components/feature_extractors/utils.py
@@ -1,6 +1,5 @@
 """Utility functions to manipulate feature extractors."""
 
-from __future__ import annotations
 
 import torch
 from torch.fx.graph_module import GraphModule

--- a/src/anomalib/models/components/filters/blur.py
+++ b/src/anomalib/models/components/filters/blur.py
@@ -1,6 +1,5 @@
 """Gaussian blurring via pytorch."""
 
-from __future__ import annotations
 
 from kornia.filters import get_gaussian_kernel2d
 from kornia.filters.filter import _compute_padding

--- a/src/anomalib/models/components/flow/all_in_one_block.py
+++ b/src/anomalib/models/components/flow/all_in_one_block.py
@@ -6,7 +6,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import warnings
 from typing import Callable

--- a/src/anomalib/models/components/sampling/k_center_greedy.py
+++ b/src/anomalib/models/components/sampling/k_center_greedy.py
@@ -5,7 +5,6 @@
     . https://arxiv.org/abs/1708.00489
 """
 
-from __future__ import annotations
 
 import torch
 import torch.nn.functional as F

--- a/src/anomalib/models/components/stats/kde.py
+++ b/src/anomalib/models/components/stats/kde.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import math
 

--- a/src/anomalib/models/components/stats/multi_variate_gaussian.py
+++ b/src/anomalib/models/components/stats/multi_variate_gaussian.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from typing import Any
 

--- a/src/anomalib/models/csflow/anomaly_map.py
+++ b/src/anomalib/models/csflow/anomaly_map.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from enum import Enum
 

--- a/src/anomalib/models/csflow/lightning_model.py
+++ b/src/anomalib/models/csflow/lightning_model.py
@@ -6,7 +6,6 @@ https://arxiv.org/pdf/2110.02855.pdf
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 

--- a/src/anomalib/models/csflow/torch_model.py
+++ b/src/anomalib/models/csflow/torch_model.py
@@ -11,8 +11,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from __future__ import annotations
-
 from math import exp
 
 import numpy as np

--- a/src/anomalib/models/dfkde/lightning_model.py
+++ b/src/anomalib/models/dfkde/lightning_model.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 

--- a/src/anomalib/models/dfkde/torch_model.py
+++ b/src/anomalib/models/dfkde/torch_model.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 
@@ -12,10 +11,7 @@ import torch.nn.functional as F
 from torch import Tensor, nn
 
 from anomalib.models.components import FeatureExtractor
-from anomalib.models.components.classification import (
-    FeatureScalingMethod,
-    KDEClassifier,
-)
+from anomalib.models.components.classification import FeatureScalingMethod, KDEClassifier
 
 logger = logging.getLogger(__name__)
 

--- a/src/anomalib/models/dfm/lightning_model.py
+++ b/src/anomalib/models/dfm/lightning_model.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 

--- a/src/anomalib/models/dfm/torch_model.py
+++ b/src/anomalib/models/dfm/torch_model.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import math
 

--- a/src/anomalib/models/draem/lightning_model.py
+++ b/src/anomalib/models/draem/lightning_model.py
@@ -6,7 +6,6 @@ Paper https://arxiv.org/abs/2108.07610
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from typing import Callable
 

--- a/src/anomalib/models/draem/torch_model.py
+++ b/src/anomalib/models/draem/torch_model.py
@@ -9,7 +9,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import torch
 from torch import Tensor, nn

--- a/src/anomalib/models/efficient_ad/lightning_model.py
+++ b/src/anomalib/models/efficient_ad/lightning_model.py
@@ -5,7 +5,6 @@ https://arxiv.org/pdf/2303.14535.pdf
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 from pathlib import Path

--- a/src/anomalib/models/efficient_ad/torch_model.py
+++ b/src/anomalib/models/efficient_ad/torch_model.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 import random

--- a/src/anomalib/models/fastflow/anomaly_map.py
+++ b/src/anomalib/models/fastflow/anomaly_map.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import torch
 import torch.nn.functional as F

--- a/src/anomalib/models/fastflow/lightning_model.py
+++ b/src/anomalib/models/fastflow/lightning_model.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import torch
 from lightning.pytorch.callbacks import EarlyStopping

--- a/src/anomalib/models/fastflow/loss.py
+++ b/src/anomalib/models/fastflow/loss.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import torch
 from torch import Tensor, nn

--- a/src/anomalib/models/fastflow/torch_model.py
+++ b/src/anomalib/models/fastflow/torch_model.py
@@ -9,7 +9,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from typing import Callable
 

--- a/src/anomalib/models/ganomaly/lightning_model.py
+++ b/src/anomalib/models/ganomaly/lightning_model.py
@@ -6,7 +6,6 @@ https://arxiv.org/abs/1805.06725
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 

--- a/src/anomalib/models/ganomaly/loss.py
+++ b/src/anomalib/models/ganomaly/loss.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import torch
 from torch import Tensor, nn

--- a/src/anomalib/models/ganomaly/torch_model.py
+++ b/src/anomalib/models/ganomaly/torch_model.py
@@ -9,7 +9,6 @@ Code adapted from https://github.com/samet-akcay/ganomaly.
 # Copyright (C) 2020-2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import math
 

--- a/src/anomalib/models/padim/anomaly_map.py
+++ b/src/anomalib/models/padim/anomaly_map.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import torch
 import torch.nn.functional as F

--- a/src/anomalib/models/padim/lightning_model.py
+++ b/src/anomalib/models/padim/lightning_model.py
@@ -6,7 +6,6 @@ Paper https://arxiv.org/abs/2011.08785
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 

--- a/src/anomalib/models/padim/torch_model.py
+++ b/src/anomalib/models/padim/torch_model.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from random import sample
 

--- a/src/anomalib/models/patchcore/anomaly_map.py
+++ b/src/anomalib/models/patchcore/anomaly_map.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import torch.nn.functional as F
 from omegaconf import ListConfig

--- a/src/anomalib/models/reverse_distillation/anomaly_map.py
+++ b/src/anomalib/models/reverse_distillation/anomaly_map.py
@@ -9,7 +9,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from enum import Enum
 

--- a/src/anomalib/models/reverse_distillation/components/bottleneck.py
+++ b/src/anomalib/models/reverse_distillation/components/bottleneck.py
@@ -10,8 +10,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from __future__ import annotations
-
 from typing import Callable
 
 import torch

--- a/src/anomalib/models/reverse_distillation/components/de_resnet.py
+++ b/src/anomalib/models/reverse_distillation/components/de_resnet.py
@@ -9,7 +9,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from typing import Any, Callable
 

--- a/src/anomalib/models/reverse_distillation/lightning_model.py
+++ b/src/anomalib/models/reverse_distillation/lightning_model.py
@@ -6,7 +6,6 @@ https://arxiv.org/abs/2201.10703v2
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from lightning.pytorch.callbacks import EarlyStopping
 from lightning.pytorch.utilities.types import STEP_OUTPUT

--- a/src/anomalib/models/reverse_distillation/loss.py
+++ b/src/anomalib/models/reverse_distillation/loss.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import torch
 from torch import Tensor, nn

--- a/src/anomalib/models/reverse_distillation/torch_model.py
+++ b/src/anomalib/models/reverse_distillation/torch_model.py
@@ -3,16 +3,12 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from torch import Tensor, nn
 
 from anomalib.models.components import FeatureExtractor
 from anomalib.models.reverse_distillation.anomaly_map import AnomalyMapGenerator
-from anomalib.models.reverse_distillation.components import (
-    get_bottleneck_layer,
-    get_decoder,
-)
+from anomalib.models.reverse_distillation.components import get_bottleneck_layer, get_decoder
 from anomalib.pre_processing import Tiler
 
 from .anomaly_map import AnomalyMapGenerationMode

--- a/src/anomalib/models/rkde/lightning_model.py
+++ b/src/anomalib/models/rkde/lightning_model.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 

--- a/src/anomalib/models/rkde/region_extractor.py
+++ b/src/anomalib/models/rkde/region_extractor.py
@@ -6,7 +6,6 @@ Region Extractor.
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from enum import Enum
 

--- a/src/anomalib/models/rkde/torch_model.py
+++ b/src/anomalib/models/rkde/torch_model.py
@@ -3,17 +3,13 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 
 import torch
 from torch import Tensor, nn
 
-from anomalib.models.components.classification import (
-    FeatureScalingMethod,
-    KDEClassifier,
-)
+from anomalib.models.components.classification import FeatureScalingMethod, KDEClassifier
 from anomalib.models.rkde.feature_extractor import FeatureExtractor
 from anomalib.models.rkde.region_extractor import RegionExtractor, RoiStage
 

--- a/src/anomalib/models/stfpm/anomaly_map.py
+++ b/src/anomalib/models/stfpm/anomaly_map.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import torch
 import torch.nn.functional as F

--- a/src/anomalib/models/stfpm/lightning_model.py
+++ b/src/anomalib/models/stfpm/lightning_model.py
@@ -6,7 +6,6 @@ https://arxiv.org/abs/2103.04257
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import torch
 from lightning.pytorch.callbacks import EarlyStopping

--- a/src/anomalib/models/stfpm/loss.py
+++ b/src/anomalib/models/stfpm/loss.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import torch
 import torch.nn.functional as F

--- a/src/anomalib/models/stfpm/torch_model.py
+++ b/src/anomalib/models/stfpm/torch_model.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from torch import Tensor, nn
 

--- a/src/anomalib/post_processing/normalization/cdf.py
+++ b/src/anomalib/post_processing/normalization/cdf.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import numpy as np
 import torch

--- a/src/anomalib/post_processing/normalization/min_max.py
+++ b/src/anomalib/post_processing/normalization/min_max.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import numpy as np
 import torch

--- a/src/anomalib/post_processing/post_process.py
+++ b/src/anomalib/post_processing/post_process.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from __future__ import annotations
-
 import math
 from enum import Enum
 

--- a/src/anomalib/post_processing/visualizer.py
+++ b/src/anomalib/post_processing/visualizer.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum

--- a/src/anomalib/pre_processing/pre_process.py
+++ b/src/anomalib/pre_processing/pre_process.py
@@ -7,7 +7,6 @@ to an input image before the forward-pass stage.
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 import warnings

--- a/src/anomalib/pre_processing/tiler.py
+++ b/src/anomalib/pre_processing/tiler.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from enum import Enum
 from itertools import product

--- a/src/anomalib/pre_processing/transforms/custom.py
+++ b/src/anomalib/pre_processing/transforms/custom.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import warnings
 

--- a/src/anomalib/utils/callbacks/__init__.py
+++ b/src/anomalib/utils/callbacks/__init__.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 import os
@@ -125,9 +124,7 @@ def get_callbacks(config: DictConfig | ListConfig) -> list[Callback]:
                 )
             )
         if config.optimization.export_mode is not None:
-            from .export import (  # pylint: disable=import-outside-toplevel
-                ExportCallback,
-            )
+            from .export import ExportCallback  # pylint: disable=import-outside-toplevel
 
             logger.info("Setting model export to %s", config.optimization.export_mode)
             callbacks.append(

--- a/src/anomalib/utils/callbacks/cdf_normalization.py
+++ b/src/anomalib/utils/callbacks/cdf_normalization.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 from typing import Any

--- a/src/anomalib/utils/callbacks/export.py
+++ b/src/anomalib/utils/callbacks/export.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 from pathlib import Path

--- a/src/anomalib/utils/callbacks/metrics_configuration.py
+++ b/src/anomalib/utils/callbacks/metrics_configuration.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from __future__ import annotations
-
 import logging
 
 import lightning.pytorch as pl

--- a/src/anomalib/utils/callbacks/min_max_normalization.py
+++ b/src/anomalib/utils/callbacks/min_max_normalization.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from typing import Any
 

--- a/src/anomalib/utils/callbacks/model_loader.py
+++ b/src/anomalib/utils/callbacks/model_loader.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 

--- a/src/anomalib/utils/callbacks/nncf/callback.py
+++ b/src/anomalib/utils/callbacks/nncf/callback.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import os
 from pathlib import Path

--- a/src/anomalib/utils/callbacks/nncf/utils.py
+++ b/src/anomalib/utils/callbacks/nncf/utils.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 from copy import copy

--- a/src/anomalib/utils/callbacks/post_processing_configuration.py
+++ b/src/anomalib/utils/callbacks/post_processing_configuration.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from __future__ import annotations
-
 import logging
 
 import torch

--- a/src/anomalib/utils/callbacks/tiler_configuration.py
+++ b/src/anomalib/utils/callbacks/tiler_configuration.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from __future__ import annotations
-
 from typing import Sequence
 
 import lightning.pytorch as pl

--- a/src/anomalib/utils/callbacks/visualizer/visualizer_base.py
+++ b/src/anomalib/utils/callbacks/visualizer/visualizer_base.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from pathlib import Path
 from typing import cast

--- a/src/anomalib/utils/callbacks/visualizer/visualizer_image.py
+++ b/src/anomalib/utils/callbacks/visualizer/visualizer_image.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import math
 from pathlib import Path

--- a/src/anomalib/utils/callbacks/visualizer/visualizer_metric.py
+++ b/src/anomalib/utils/callbacks/visualizer/visualizer_metric.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from pathlib import Path
 

--- a/src/anomalib/utils/cli/cli.py
+++ b/src/anomalib/utils/cli/cli.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 import os
@@ -181,9 +180,7 @@ class AnomalibCLI(LightningCLI):
 
         # Export to OpenVINO
         if config.export_mode is not None:
-            from anomalib.utils.callbacks.export import (  # pylint: disable=import-outside-toplevel
-                ExportCallback,
-            )
+            from anomalib.utils.callbacks.export import ExportCallback  # pylint: disable=import-outside-toplevel
 
             logger.info("Setting model export to %s", config.export_mode)
             callbacks.append(

--- a/src/anomalib/utils/hpo/config.py
+++ b/src/anomalib/utils/hpo/config.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from __future__ import annotations
-
 from omegaconf import DictConfig
 
 

--- a/src/anomalib/utils/hpo/runners.py
+++ b/src/anomalib/utils/hpo/runners.py
@@ -3,25 +3,20 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import gc
 
 import lightning.pytorch as pl
 import torch
-import wandb
 from comet_ml import Optimizer
 from lightning.pytorch.loggers import CometLogger, WandbLogger
 from omegaconf import DictConfig, ListConfig, OmegaConf
 
+import wandb
 from anomalib.config import update_input_size_config
 from anomalib.data import get_datamodule
 from anomalib.models import get_model
-from anomalib.utils.sweep import (
-    flatten_sweep_params,
-    get_sweep_callbacks,
-    set_in_nested_config,
-)
+from anomalib.utils.sweep import flatten_sweep_params, get_sweep_callbacks, set_in_nested_config
 
 from .config import flatten_hpo_params
 

--- a/src/anomalib/utils/loggers/__init__.py
+++ b/src/anomalib/utils/loggers/__init__.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import logging
 import os

--- a/src/anomalib/utils/loggers/base.py
+++ b/src/anomalib/utils/loggers/base.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from abc import abstractmethod
 from typing import Any

--- a/src/anomalib/utils/loggers/comet.py
+++ b/src/anomalib/utils/loggers/comet.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from typing import Any
 

--- a/src/anomalib/utils/loggers/tensorboard.py
+++ b/src/anomalib/utils/loggers/tensorboard.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from typing import Any
 

--- a/src/anomalib/utils/loggers/wandb.py
+++ b/src/anomalib/utils/loggers/wandb.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from typing import Any
 

--- a/src/anomalib/utils/metrics/__init__.py
+++ b/src/anomalib/utils/metrics/__init__.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import importlib
 import warnings

--- a/src/anomalib/utils/metrics/anomaly_score_distribution.py
+++ b/src/anomalib/utils/metrics/anomaly_score_distribution.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import torch
 from torch import Tensor

--- a/src/anomalib/utils/metrics/anomaly_score_threshold.py
+++ b/src/anomalib/utils/metrics/anomaly_score_threshold.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import warnings
 

--- a/src/anomalib/utils/metrics/aupr.py
+++ b/src/anomalib/utils/metrics/aupr.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from __future__ import annotations
-
 from matplotlib.figure import Figure
 from torch import Tensor
 from torchmetrics import PrecisionRecallCurve

--- a/src/anomalib/utils/metrics/aupro.py
+++ b/src/anomalib/utils/metrics/aupro.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from typing import Any, Callable
 
@@ -15,10 +14,7 @@ from torchmetrics.functional import auc
 from torchmetrics.functional.classification import binary_roc
 from torchmetrics.utilities.data import dim_zero_cat
 
-from anomalib.utils.metrics.pro import (
-    connected_components_cpu,
-    connected_components_gpu,
-)
+from anomalib.utils.metrics.pro import connected_components_cpu, connected_components_gpu
 
 from .binning import thresholds_between_0_and_1, thresholds_between_min_and_max
 from .plotting_utils import plot_figure

--- a/src/anomalib/utils/metrics/auroc.py
+++ b/src/anomalib/utils/metrics/auroc.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from matplotlib.figure import Figure
 from torch import Tensor

--- a/src/anomalib/utils/metrics/min_max.py
+++ b/src/anomalib/utils/metrics/min_max.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import torch
 from torch import Tensor

--- a/src/anomalib/utils/metrics/plotting_utils.py
+++ b/src/anomalib/utils/metrics/plotting_utils.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import torch
 from matplotlib import pyplot as plt

--- a/src/anomalib/utils/metrics/pro.py
+++ b/src/anomalib/utils/metrics/pro.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import torch
 from torch import Tensor

--- a/src/anomalib/utils/sweep/config.py
+++ b/src/anomalib/utils/sweep/config.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import itertools
 import operator

--- a/src/anomalib/utils/sweep/helpers/callbacks.py
+++ b/src/anomalib/utils/sweep/helpers/callbacks.py
@@ -4,15 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from __future__ import annotations
-
 from lightning.pytorch import Callback
 from omegaconf import DictConfig, ListConfig
 
-from anomalib.utils.callbacks import (
-    MetricsConfigurationCallback,
-    PostProcessingConfigurationCallback,
-)
+from anomalib.utils.callbacks import MetricsConfigurationCallback, PostProcessingConfigurationCallback
 from anomalib.utils.callbacks.timer import TimerCallback
 
 

--- a/src/anomalib/utils/sweep/helpers/inference.py
+++ b/src/anomalib/utils/sweep/helpers/inference.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import time
 from pathlib import Path

--- a/tests/pre_merge/tools/conftest.py
+++ b/tests/pre_merge/tools/conftest.py
@@ -2,8 +2,6 @@
 
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-from __future__ import annotations
-
 from tempfile import TemporaryDirectory
 from typing import Generator
 

--- a/tests/pre_merge/tools/test_gradio_entrypoint.py
+++ b/tests/pre_merge/tools/test_gradio_entrypoint.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from __future__ import annotations
-
 import sys
 from importlib.util import find_spec
 

--- a/tests/pre_merge/tools/test_lightning_entrypoint.py
+++ b/tests/pre_merge/tools/test_lightning_entrypoint.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from __future__ import annotations
-
 import sys
 from importlib.util import find_spec
 

--- a/tests/pre_merge/tools/test_openvino_entrypoint.py
+++ b/tests/pre_merge/tools/test_openvino_entrypoint.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from __future__ import annotations
-
 import sys
 from importlib.util import find_spec
 

--- a/tests/pre_merge/tools/test_test_entrypoint.py
+++ b/tests/pre_merge/tools/test_test_entrypoint.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import sys
 from importlib.util import find_spec

--- a/tests/pre_merge/tools/test_torch_entrypoint.py
+++ b/tests/pre_merge/tools/test_torch_entrypoint.py
@@ -4,8 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from __future__ import annotations
-
 import sys
 from importlib.util import find_spec
 

--- a/tools/benchmarking/benchmark.py
+++ b/tools/benchmarking/benchmark.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import functools
 import io

--- a/tools/benchmarking/utils/metrics.py
+++ b/tools/benchmarking/utils/metrics.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 import random
 import string
@@ -11,9 +10,10 @@ from glob import glob
 from pathlib import Path
 
 import pandas as pd
-import wandb
 from comet_ml import Experiment
 from torch.utils.tensorboard.writer import SummaryWriter
+
+import wandb
 
 
 def write_metrics(

--- a/tools/hpo/sweep.py
+++ b/tools/hpo/sweep.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from argparse import ArgumentParser
 from pathlib import Path

--- a/tools/inference/gradio_inference.py
+++ b/tools/inference/gradio_inference.py
@@ -6,7 +6,6 @@ This script provide a gradio web interface
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
 
 from argparse import ArgumentParser
 from importlib import import_module


### PR DESCRIPTION
## Description

Provide a summary of the modification as well as the issue that has been resolved.

- Removes `from __future__ import annotation`. This is because jsonargparse does not work will with future annotation.
- This is a breaking change as restricts python to version 3.10 and greater.

## Changes

<details>
<summary>Describe the changes you made</summary>

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

</details>

## Checklist

<details>
<summary>Ensure that you followed the following</summary>

- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (If applicable)
- [ ] I have made corresponding changes to the documentation (If applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (If applicable)

</details>
