### PR TITLE
Modify workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,9 @@
 name: Upload Python Package
 on:
   release:
-    types: [created]
+    types: [published]
+  workflow_dispatch: # run on request (no need for PR)
+
 jobs:
   deploy:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
## Description

- Modifies publish workflow to run when a release is puslished. The problem with create is that if you first save it as a draft then the workflow will not run.
- Adds manual trigger.
