### PR TITLE
[Chore] Modify README custom dataset 

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ dataset:
   normalization: imagenet # data distribution to which the images will be normalized: [none, imagenet]
   test_split_mode: from_dir # options: [from_dir, synthetic]
   val_split_mode: same_as_test # options: [same_as_test, from_test, sythetic]
+  val_split_ratio: 0.5 # fraction of train/test images held out for validation (usage depends on val_split_mode)  
   transform_config:
     train: null
     val: null

--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ dataset:
   train_batch_size: 32
   test_batch_size: 32
   num_workers: 8
+  normalization: imagenet # data distribution to which the images will be normalized: [none, imagenet]
+  test_split_mode: from_dir # options: [from_dir, synthetic]
+  val_split_mode: same_as_test # options: [same_as_test, from_test, sythetic]
   transform_config:
     train: null
     val: null


### PR DESCRIPTION
## Description

An error occurs because the custom database on README.md does not have four required keys: normalization, val_split_mode, and test_split_mode. 

So I added that key.