### PR TITLE
Fix PRO metric calculation on GPU

### DIFF
--- a/src/anomalib/utils/metrics/pro.py
+++ b/src/anomalib/utils/metrics/pro.py
@@ -38,8 +38,7 @@ class PRO(Metric):
         target = dim_zero_cat(self.target)
         preds = dim_zero_cat(self.preds)
 
-        target = target.unsqueeze(1)  # kornia expects N1HW format
-        target = target.type(torch.float)  # kornia expects FloatTensor
+        target = target.unsqueeze(1).type(torch.float)  # kornia expects N1HW and FloatTensor format
         if target.is_cuda:
             comps = connected_components_gpu(target)
         else:

--- a/src/anomalib/utils/metrics/pro.py
+++ b/src/anomalib/utils/metrics/pro.py
@@ -38,10 +38,12 @@ class PRO(Metric):
         target = dim_zero_cat(self.target)
         preds = dim_zero_cat(self.preds)
 
+        target = target.unsqueeze(1)  # kornia expects N1HW format
+        target = target.type(torch.float)  # kornia expects FloatTensor
         if target.is_cuda:
-            comps = connected_components_gpu(target.unsqueeze(1))
+            comps = connected_components_gpu(target)
         else:
-            comps = connected_components_cpu(target.unsqueeze(1))
+            comps = connected_components_cpu(target)
         pro = pro_score(preds, comps, threshold=self.threshold)
         return pro
 
@@ -63,6 +65,8 @@ def pro_score(predictions: Tensor, comps: Tensor, threshold: float = 0.5) -> Ten
     n_comps = len(comps.unique())
 
     preds = comps.clone()
+    # match the shapes in case one of the tensors is N1HW
+    preds = preds.reshape(predictions.shape)
     preds[~predictions] = 0
     if n_comps == 1:  # only background
         return torch.Tensor([1.0])

--- a/tests/pre_merge/utils/metrics/test_pro.py
+++ b/tests/pre_merge/utils/metrics/test_pro.py
@@ -29,9 +29,13 @@ def test_pro():
             ]
         ]
     )
+    # ground truth mask is int type
+    labels = labels.type(torch.int32)
+
 
     preds = (torch.arange(10) / 10) + 0.05
-    preds = preds.unsqueeze(1).repeat(1, 5).view(1, 1, 10, 5)
+    # metrics receive squeezed predictions (N, H, W)
+    preds = preds.unsqueeze(1).repeat(1, 5).view(1, 10, 5)
 
     thresholds = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]
     targets = [1.0, 0.8, 0.6, 0.4, 0.2, 0.0]
@@ -49,8 +53,10 @@ def test_device_consistency():
     batch = torch.zeros((32, 256, 256))
     for i in range(batch.shape[0]):
         batch[i, ...] = random_2d_perlin((256, 256), (torch.tensor(4), torch.tensor(4))) > 0.5
+    # ground truth mask is int type
+    batch = batch.type(torch.int32)
 
-    preds = transform(batch).unsqueeze(1)
+    preds = transform(batch)
 
     pro_cpu = PRO()
     pro_gpu = PRO()

--- a/tests/pre_merge/utils/metrics/test_pro.py
+++ b/tests/pre_merge/utils/metrics/test_pro.py
@@ -32,7 +32,6 @@ def test_pro():
     # ground truth mask is int type
     labels = labels.type(torch.int32)
 
-
     preds = (torch.arange(10) / 10) + 0.05
     # metrics receive squeezed predictions (N, H, W)
     preds = preds.unsqueeze(1).repeat(1, 5).view(1, 10, 5)


### PR DESCRIPTION
## Description

Fixes PRO metric calculation on GPU by changing type to float, as well as matches shapes so it works with predictions of shape N, H, W.
I also adjusted tests to verify that it does works with relevant shapes and types.

- Fixes #1316 

## Changes

<details>
<summary>Describe the changes you made</summary>

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

</details>

## Checklist

<details>
<summary>Ensure that you followed the following</summary>

- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (If applicable)
- [ ] I have made corresponding changes to the documentation (If applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (If applicable)

</details>
