### PR TITLE
Fix dockerfile cuda version

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -5,7 +5,7 @@ ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY
 
-FROM nvidia/cuda:11.4.0-devel-ubuntu20.04 AS python_base_cuda11.4
+FROM nvidia/cuda:11.4.3-devel-ubuntu20.04 AS python_base_cuda11.4
 LABEL maintainer="Anomalib Development Team"
 
 # Setup proxies


### PR DESCRIPTION
## Description

Docker fails to run when running from image `nvidia/cuda:11.4.0-devel-ubuntu20.04`. This version does not exist on DockerHub (instead, it is version 11.4.3)

## Changes

<details>
<summary>Changed cuda version from 11.4.0 to 11.4.3</summary>

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

</details>

## Checklist

<details>
<summary>Ensure that you followed the following</summary>

- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (If applicable)
- [ ] I have made corresponding changes to the documentation (If applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (If applicable)

</details>
