### PR TITLE
Fix patchcore interpolation

### DIFF
--- a/src/anomalib/models/patchcore/torch_model.py
+++ b/src/anomalib/models/patchcore/torch_model.py
@@ -107,7 +107,7 @@ class PatchcoreModel(DynamicBufferModule, nn.Module):
         embeddings = features[self.layers[0]]
         for layer in self.layers[1:]:
             layer_embedding = features[layer]
-            layer_embedding = F.interpolate(layer_embedding, size=embeddings.shape[-2:], mode="nearest")
+            layer_embedding = F.interpolate(layer_embedding, size=embeddings.shape[-2:], mode="bilinear")
             embeddings = torch.cat((embeddings, layer_embedding), 1)
 
         return embeddings

--- a/src/anomalib/models/patchcore/torch_model.py
+++ b/src/anomalib/models/patchcore/torch_model.py
@@ -208,7 +208,10 @@ class PatchcoreModel(DynamicBufferModule, nn.Module):
         # 3. Find the support samples of the nearest neighbor in the membank
         nn_sample = self.memory_bank[nn_index, :]  # m^* in the paper
         # indices of N_b(m^*) in the paper
-        _, support_samples = self.nearest_neighbors(nn_sample, n_neighbors=self.num_neighbors)
+        memory_bank_effective_size = self.memory_bank.shape[0]  # edge case when memory bank is too small
+        _, support_samples = self.nearest_neighbors(
+            nn_sample, n_neighbors=min(self.num_neighbors, memory_bank_effective_size)
+        )
         # 4. Find the distance of the patch features to each of the support samples
         distances = self.euclidean_dist(max_patches_features.unsqueeze(1), self.memory_bank[support_samples])
         # 5. Apply softmax to find the weights


### PR DESCRIPTION
## Description

Straighforward fix.

- Fixes #1334 

Additionally deal with an edge case where the memory bank ends up being smaller than `num_neighbors` (computation of the image-wise score).

## Changes

<details>
<summary>Describe the changes you made</summary>

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

</details>

## Checklist

<details>
<summary>Ensure that you followed the following</summary>

- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas (If applicable)
- [ ] I have made corresponding changes to the documentation (If applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (If applicable)

</details>
