### PR TITLE
Efficient ad reduced memory footprint

### DIFF
--- a/src/anomalib/models/efficient_ad/lightning_model.py
+++ b/src/anomalib/models/efficient_ad/lightning_model.py
@@ -142,7 +142,7 @@ class EfficientAd(AnomalyModule):
                 y = self.model.teacher(batch["image"].to(self.device))
                 y_means.append(torch.mean(y, dim=[0, 2, 3]))
                 teacher_outputs.append(y)
-        except RuntimeError as e:
+        except RuntimeError:
             teacher_outputs = []
             y_means = []
             torch.cuda.empty_cache()

--- a/src/anomalib/models/efficient_ad/lightning_model.py
+++ b/src/anomalib/models/efficient_ad/lightning_model.py
@@ -137,16 +137,31 @@ class EfficientAd(AnomalyModule):
         means_distance = []
 
         logger.info("Calculate teacher channel mean and std")
-        for batch in tqdm.tqdm(dataloader, desc="Calculate teacher channel mean", position=0, leave=True):
-            y = self.model.teacher(batch["image"].to(self.device))
-            y_means.append(torch.mean(y, dim=[0, 2, 3]))
-            teacher_outputs.append(y)
+        try:
+            for batch in tqdm.tqdm(dataloader, desc="Calculate teacher channel mean", position=0, leave=True):
+                y = self.model.teacher(batch["image"].to(self.device))
+                y_means.append(torch.mean(y, dim=[0, 2, 3]))
+                teacher_outputs.append(y)
+        except RuntimeError as e:
+            teacher_outputs = []
+            y_means = []
+            torch.cuda.empty_cache()
+            logger.info("Recovering from OutOfMemory Exception by using workaround with longer runtime")
+            for batch in tqdm.tqdm(dataloader, desc="Calculate teacher channel mean", position=0, leave=True):
+                y = self.model.teacher(batch["image"].to(self.device))
+                y_means.append(torch.mean(y, dim=[0, 2, 3]))
 
         channel_mean = torch.mean(torch.stack(y_means), dim=0)[None, :, None, None]
 
-        for y in tqdm.tqdm(teacher_outputs, desc="Calculate teacher channel std", position=0, leave=True):
-            distance = (y - channel_mean) ** 2
-            means_distance.append(torch.mean(distance, dim=[0, 2, 3]))
+        if len(teacher_outputs) > 0:
+            for y in tqdm.tqdm(teacher_outputs, desc="Calculate teacher channel std", position=0, leave=True):
+                distance = (y - channel_mean) ** 2
+                means_distance.append(torch.mean(distance, dim=[0, 2, 3]))
+        else:
+            for batch in tqdm.tqdm(dataloader, desc="Calculate teacher channel std", position=0, leave=True):
+                y = self.model.teacher(batch["image"].to(self.device))
+                distance = (y - channel_mean) ** 2
+                means_distance.append(torch.mean(distance, dim=[0, 2, 3]))
 
         channel_var = torch.mean(torch.stack(means_distance), dim=0)[None, :, None, None]
         channel_std = torch.sqrt(channel_var)


### PR DESCRIPTION
## Description

I ran into an OutOfMemory exception when calculating the teacher channel mean and standard deviation while training the EfficientAD model. I fixed this by not saving the teacher outputs to a list but instead iterating the dataloader twice.

- Fixes #1301 

- **TODO**: Sort out pre-commit stuff (couldn't get the pre-commit hooks running)

- Maybe: Implement 'online' mean and variance calculation, see https://github.com/openvinotoolkit/anomalib/issues/1301#issuecomment-1693126642

## Changes

<details>
<summary>Describe the changes you made</summary>

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

</details>

## Checklist

<details>
<summary>Ensure that you followed the following</summary>

- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (If applicable)
- [ ] I have made corresponding changes to the documentation (If applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (If applicable)

</details>
