### PR TITLE
Add support to backbone URI in config.

### DIFF
--- a/src/anomalib/models/components/feature_extractors/timm.py
+++ b/src/anomalib/models/components/feature_extractors/timm.py
@@ -45,6 +45,16 @@ class TimmFeatureExtractor(nn.Module):
 
     def __init__(self, backbone: str, layers: list[str], pre_trained: bool = True, requires_grad: bool = False):
         super().__init__()
+
+        # Extract backbone-name and weight-URI from the backbone string.
+        if "__AT__" in backbone:
+            backbone, uri = backbone.split("__AT__")
+            pretrained_cfg = timm.models.registry.get_pretrained_cfg(backbone)
+            # Override pretrained_cfg["url"] to use different pretrained weights.
+            pretrained_cfg["url"] = uri
+        else:
+            pretrained_cfg = None
+
         self.backbone = backbone
         self.layers = layers
         self.idx = self._map_layer_to_idx()
@@ -52,6 +62,7 @@ class TimmFeatureExtractor(nn.Module):
         self.feature_extractor = timm.create_model(
             backbone,
             pretrained=pre_trained,
+            pretrained_cfg=pretrained_cfg,
             features_only=True,
             exportable=True,
             out_indices=self.idx,


### PR DESCRIPTION
## Description

This PR adds support to loading pretrained backbone weights from a URI in the config.

For example:
```yaml
model:
  backbone: resnet18__AT__https://download.pytorch.org/models/resnet18-5c106cde.pth
```

```yaml
model:
  backbone: resnet18__AT__file:///home/user.cache/torch/hub/checkpoints/resnet18-5c106cde.pth
```

Caveat: The weight loading may fail quietly because of `strict=False`. Users need to make sure the weight file works for the model.

## Changes

<details>
<summary>Describe the changes you made</summary>

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

</details>

## Checklist

<details>
<summary>Ensure that you followed the following</summary>

- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (If applicable)
- [ ] I have made corresponding changes to the documentation (If applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (If applicable)

</details>
