### PR TITLE
Allow overriding configs in the command line.

### DIFF
--- a/src/anomalib/config/config.py
+++ b/src/anomalib/config/config.py
@@ -204,6 +204,7 @@ def update_datasets_config(config: DictConfig | ListConfig) -> DictConfig | List
 def get_configurable_parameters(
     model_name: str | None = None,
     config_path: Path | str | None = None,
+    overrides: list[str] | None = None,
     weight_file: str | None = None,
     config_filename: str | None = "config",
     config_file_extension: str | None = "yaml",
@@ -213,6 +214,7 @@ def get_configurable_parameters(
     Args:
         model_name: str | None:  (Default value = None)
         config_path: Path | str | None:  (Default value = None)
+        overrides: list[str] | None: (Default value = None)
         weight_file: Path to the weight file
         config_filename: str | None:  (Default value = "config")
         config_file_extension: str | None:  (Default value = "yaml")
@@ -234,6 +236,8 @@ def get_configurable_parameters(
         config_path = Path(f"src/anomalib/models/{model_name}/{config_filename}.{config_file_extension}")
 
     config = OmegaConf.load(config_path)
+    # Override config immediately after loading from path.
+    config.merge_with_dotlist(overrides)
 
     # keep track of the original config file because it will be modified
     config_original: DictConfig = config.copy()

--- a/tools/train.py
+++ b/tools/train.py
@@ -34,6 +34,11 @@ def get_parser() -> ArgumentParser:
     parser.add_argument("--model", type=str, default="padim", help="Name of the algorithm to train/test")
     parser.add_argument("--config", type=str, required=False, help="Path to a model config file")
     parser.add_argument("--log-level", type=str, default="INFO", help="<DEBUG, INFO, WARNING, ERROR>")
+    parser.add_argument(
+        "overrides",
+        nargs="*",
+        help="Any key=value arguments to override config values (use dots for.nested=overrides)",
+    )
 
     return parser
 
@@ -50,7 +55,7 @@ def train(args: Namespace):
     if args.log_level == "ERROR":
         warnings.filterwarnings("ignore")
 
-    config = get_configurable_parameters(model_name=args.model, config_path=args.config)
+    config = get_configurable_parameters(model_name=args.model, config_path=args.config, overrides=args.overrides)
     if config.project.get("seed") is not None:
         seed_everything(config.project.seed)
 


### PR DESCRIPTION
## Description

This PR allows users to override config in the command line to help scale up experiments without generating new config files.

Example:
```bash
python tools/train.py --model=padim dataset.category=zipper
```

## Changes

<details>
<summary>Describe the changes you made</summary>

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

</details>

## Checklist

<details>
<summary>Ensure that you followed the following</summary>

- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (If applicable)
- [ ] I have made corresponding changes to the documentation (If applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (If applicable)

</details>
