### PR TITLE
Allow dynamic batch-sizes when exporting to ONNX, instead if fixed input shapes

### DIFF
--- a/src/anomalib/deploy/export.py
+++ b/src/anomalib/deploy/export.py
@@ -159,6 +159,10 @@ def export_to_onnx(model: AnomalyModule, input_size: tuple[int, int], export_pat
         torch.zeros((1, 3, *input_size)).to(model.device),
         str(onnx_path),
         opset_version=11,
+        dynamic_axes={
+                        'input'  : {0 : 'batch_size'},
+                        'output' : {0 : 'batch_size'}
+                      },
         input_names=["input"],
         output_names=["output"],
     )

--- a/src/anomalib/deploy/export.py
+++ b/src/anomalib/deploy/export.py
@@ -159,10 +159,7 @@ def export_to_onnx(model: AnomalyModule, input_size: tuple[int, int], export_pat
         torch.zeros((1, 3, *input_size)).to(model.device),
         str(onnx_path),
         opset_version=11,
-        dynamic_axes={
-                        'input'  : {0 : 'batch_size'},
-                        'output' : {0 : 'batch_size'}
-                      },
+        dynamic_axes={"input": {0: "batch_size"}, "output": {0: "batch_size"}},
         input_names=["input"],
         output_names=["output"],
     )


### PR DESCRIPTION
## Description

When exporting to ONNX the models input shape is fixed to a batch-size of 1. This only allows to feed single images into the resuting anomaly model. 

Torch.onnx allows to define dynamic axes when exporting the model, which enables dynamic batch-sizes. 

- Fixes # (issue)

## Changes

<details>
<summary>Describe the changes you made</summary>

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

</details>

## Checklist

<details>
<summary>Ensure that you followed the following</summary>

- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (If applicable)
- [ ] I have made corresponding changes to the documentation (If applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (If applicable)

</details>
