### PR TITLE
Fix EfficientAD to use width and height of the input

### DIFF
--- a/src/anomalib/models/efficient_ad/torch_model.py
+++ b/src/anomalib/models/efficient_ad/torch_model.py
@@ -147,7 +147,7 @@ class Decoder(nn.Module):
     def __init__(self, out_channels, padding, img_size, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.img_size = img_size
-       self.last_upsample = (
+        self.last_upsample = (
             int(img_size[0] / 4) if padding else int(img_size[0] / 4) - 8,
             int(img_size[1] / 4) if padding else int(img_size[1] / 4) - 8,
         )

--- a/src/anomalib/models/efficient_ad/torch_model.py
+++ b/src/anomalib/models/efficient_ad/torch_model.py
@@ -141,12 +141,14 @@ class Decoder(nn.Module):
 
     Args:
         out_channels (int): number of convolution output channels
+        img_size (tuple): size of input images
     """
 
     def __init__(self, out_channels, padding, img_size, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.img_size = img_size
-        self.last_upsample = int(img_size / 4) if padding else int(img_size / 4) - 8
+        self.last_upsample = (int(img_size[0] / 4) if padding else int(img_size[0] / 4) - 8,
+                              int(img_size[1] / 4) if padding else int(img_size[1] / 4) - 8)
         self.deconv1 = nn.Conv2d(64, 64, kernel_size=4, stride=1, padding=2)
         self.deconv2 = nn.Conv2d(64, 64, kernel_size=4, stride=1, padding=2)
         self.deconv3 = nn.Conv2d(64, 64, kernel_size=4, stride=1, padding=2)
@@ -163,22 +165,22 @@ class Decoder(nn.Module):
         self.dropout6 = nn.Dropout(p=0.2)
 
     def forward(self, x):
-        x = F.interpolate(x, size=int(self.img_size / 64) - 1, mode="bilinear")
+        x = F.interpolate(x, size=(int(self.img_size[0] / 64) - 1, int(self.img_size[1] / 64) - 1), mode="bilinear")
         x = F.relu(self.deconv1(x))
         x = self.dropout1(x)
-        x = F.interpolate(x, size=int(self.img_size / 32), mode="bilinear")
+        x = F.interpolate(x, size=(int(self.img_size[0] / 32), int(self.img_size[1] / 32)), mode="bilinear")
         x = F.relu(self.deconv2(x))
         x = self.dropout2(x)
-        x = F.interpolate(x, size=int(self.img_size / 16) - 1, mode="bilinear")
+        x = F.interpolate(x, size=(int(self.img_size[0] / 16) - 1, int(self.img_size[1] / 16) - 1), mode="bilinear")
         x = F.relu(self.deconv3(x))
         x = self.dropout3(x)
-        x = F.interpolate(x, size=int(self.img_size / 8), mode="bilinear")
+        x = F.interpolate(x, size=(int(self.img_size[0] / 8), int(self.img_size[1] / 8)), mode="bilinear")
         x = F.relu(self.deconv4(x))
         x = self.dropout4(x)
-        x = F.interpolate(x, size=int(self.img_size / 4) - 1, mode="bilinear")
+        x = F.interpolate(x, size=(int(self.img_size[0] / 4) - 1, int(self.img_size[1] / 4) - 1), mode="bilinear")
         x = F.relu(self.deconv5(x))
         x = self.dropout5(x)
-        x = F.interpolate(x, size=int(self.img_size / 2) - 1, mode="bilinear")
+        x = F.interpolate(x, size=(int(self.img_size[0] / 2) - 1, int(self.img_size[1] / 2) - 1), mode="bilinear")
         x = F.relu(self.deconv6(x))
         x = self.dropout6(x)
         x = F.interpolate(x, size=self.last_upsample, mode="bilinear")
@@ -192,6 +194,7 @@ class AutoEncoder(nn.Module):
 
     Args:
        out_channels (int): number of convolution output channels
+       img_size (tuple): size of input images
     """
 
     def __init__(self, out_channels, padding, img_size, *args, **kwargs) -> None:
@@ -245,7 +248,7 @@ class EfficientAdModel(nn.Module):
         else:
             raise ValueError(f"Unknown model size {model_size}")
 
-        self.ae: AutoEncoder = AutoEncoder(out_channels=teacher_out_channels, padding=padding, img_size=input_size[0])
+        self.ae: AutoEncoder = AutoEncoder(out_channels=teacher_out_channels, padding=padding, img_size=input_size)
         self.teacher_out_channels: int = teacher_out_channels
         self.input_size: tuple[int, int] = input_size
 

--- a/src/anomalib/models/efficient_ad/torch_model.py
+++ b/src/anomalib/models/efficient_ad/torch_model.py
@@ -147,8 +147,10 @@ class Decoder(nn.Module):
     def __init__(self, out_channels, padding, img_size, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.img_size = img_size
-        self.last_upsample = (int(img_size[0] / 4) if padding else int(img_size[0] / 4) - 8,
-                              int(img_size[1] / 4) if padding else int(img_size[1] / 4) - 8)
+       self.last_upsample = (
+            int(img_size[0] / 4) if padding else int(img_size[0] / 4) - 8,
+            int(img_size[1] / 4) if padding else int(img_size[1] / 4) - 8,
+        )
         self.deconv1 = nn.Conv2d(64, 64, kernel_size=4, stride=1, padding=2)
         self.deconv2 = nn.Conv2d(64, 64, kernel_size=4, stride=1, padding=2)
         self.deconv3 = nn.Conv2d(64, 64, kernel_size=4, stride=1, padding=2)


### PR DESCRIPTION
## Description

AutoEncoder in EfficientAD uses both the width and height of the original image for upscaling, and the size of its output matches the output of other models. 

- Fixes #1352,  mentioned in [this comment](https://github.com/openvinotoolkit/anomalib/issues/1352#issuecomment-1731175752),
Training of EfficientAD fails if the input image has a different width and height:
```
File "./anomalib/src/anomalib/models/efficient_ad/torch_model.py", line 322, in forward
    distance_ae = torch.pow(teacher_output_aug - ae_output_aug, 2)
RuntimeError: The size of tensor a (56) must match the size of tensor b (120) at non-singleton dimension 3
Epoch 0:   0%|          | 0/215 [00:00<?, ?it/s]  
```


## Changes

<details>
<summary>Describe the changes you made</summary>

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

</details>

## Checklist

<details>
<summary>Ensure that you followed the following</summary>

- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (If applicable)
- [ ] I have made corresponding changes to the documentation (If applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (If applicable)

</details>
