### PR TITLE
Missing indentation in metrics.rst docs

### DIFF
--- a/docs/source/reference_guide/api/metrics.rst
+++ b/docs/source/reference_guide/api/metrics.rst
@@ -21,11 +21,11 @@ Each subsection in the section ``metrics`` of the config file can have a differe
          F1Score:
             class_path: torchmetrics.F1Score
             init_args:
-            compute_on_cpu: true
+               compute_on_cpu: true
          AUROC:
             class_path: anomalib.utils.metrics.AUROC
             init_args:
-            compute_on_cpu: true
+               compute_on_cpu: true
 
 List of metric names
 --------------------


### PR DESCRIPTION
## Description

`compute_on_cpu` should be an internal parameter of `init_args` in the `metrics` configurations.

## Changes

Added indentation so that the format of the config file is right.

<details>
<summary>Describe the changes you made</summary>

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

</details>

## Checklist

<details>
<summary>Ensure that you followed the following</summary>

- [x] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (If applicable)
- [x] I have made corresponding changes to the documentation (If applicable)
- [x] I have added tests that prove my fix is effective or that my feature works (If applicable)

</details>
