### PR TITLE
Replace black with ruff formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,15 +13,9 @@ repos:
       - id: debug-statements
       - id: detect-private-key
 
-  # python code formatting
-  - repo: https://github.com/psf/black
-    rev: 23.9.1
-    hooks:
-      - id: black
-
   # Ruff version.
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.292"
+    rev: "v0.1.2"
     hooks:
       - id: ruff
         exclude: "tests"
@@ -29,7 +23,7 @@ repos:
 
   # python static type checking
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.6.0"
+    rev: "v1.6.1"
     hooks:
       - id: mypy
         additional_dependencies: [types-PyYAML]
@@ -39,7 +33,6 @@ repos:
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 1.7.0
     hooks:
-      - id: nbqa-black
       - id: nbqa-ruff
         # Ignore unsorted imports. This is because jupyter notebooks can import
         # packages in a different order than the rest of the codebase.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,6 @@ build-backend = "setuptools.build_meta"
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# BLACK CONFIGURATION                                                         #
-[tool.black]
-line-length = 120
-
-
-# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # RUFF CONFIGURATION                                                          #
 [tool.ruff]
 # Enable rules


### PR DESCRIPTION
## Description

Replace `black` with `ruff`. According to the author of ruff, it is 30x faster than black and 99% compatible. As can be seen from the changes, it is indeed compatible in our case. For more details, you could refer to this [link](https://twitter.com/charliermarsh/status/1716861072374657497?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet).

![image](https://github.com/openvinotoolkit/anomalib/assets/17574420/8f806291-03e1-45ea-b28d-dca080342a2f)


## Changes

<details>
<summary>Describe the changes you made</summary>

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

</details>

## Checklist

<details>
<summary>Ensure that you followed the following</summary>

- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (If applicable)
- [ ] I have made corresponding changes to the documentation (If applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (If applicable)

</details>
