### PR TITLE
Fix circular import in cdf normalizer

### DIFF
--- a/src/anomalib/callbacks/normalization/cdf_normalization.py
+++ b/src/anomalib/callbacks/normalization/cdf_normalization.py
@@ -7,10 +7,11 @@
 import logging
 from typing import TYPE_CHECKING, Any
 
+from lightning import Trainer
 from lightning.pytorch import Callback, Trainer
 from lightning.pytorch.utilities.types import STEP_OUTPUT
 
-from anomalib import engine
+from anomalib.callbacks.post_processor import _PostProcessorCallback
 from anomalib.metrics import AnomalyScoreDistribution
 from anomalib.models.components import AnomalyModule
 from anomalib.utils.normalization.cdf import normalize, standardize
@@ -116,10 +117,11 @@ class _CdfNormalizationCallback(Callback):
          estimate the distribution of anomaly scores for normal data at the image and pixel level by computing
          the mean and standard deviations. A dictionary containing the computed statistics is stored in self.stats.
         """
-        # Since CDF callback is imported in `get_normalizers` which in-turn is imported by Engine, directly referring
-        # to engine here leads to circular import error
-        _engine = engine.Engine(accelerator=trainer.accelerator, devices=trainer.num_devices, normalization="none")
-        predictions = _engine.predict(
+        predictions = Trainer(
+            accelerator=trainer.accelerator,
+            devices=trainer.num_devices,
+            callbacks=[_PostProcessorCallback()],
+        ).predict(
             model=self._create_inference_model(pl_module),
             dataloaders=trainer.datamodule.train_dataloader(),
         )

--- a/src/anomalib/callbacks/normalization/cdf_normalization.py
+++ b/src/anomalib/callbacks/normalization/cdf_normalization.py
@@ -7,7 +7,6 @@
 import logging
 from typing import TYPE_CHECKING, Any
 
-from lightning import Trainer
 from lightning.pytorch import Callback, Trainer
 from lightning.pytorch.utilities.types import STEP_OUTPUT
 


### PR DESCRIPTION
## Description

Fixes a circular import in CDF normalizer.

Fixed by collecting the normalization stats using a Lightning Trainer instance instead of an Anomalib engine.

## Changes

<details>
<summary>Describe the changes you made</summary>

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

</details>

## Checklist

<details>
<summary>Ensure that you followed the following</summary>

- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (If applicable)
- [ ] I have made corresponding changes to the documentation (If applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (If applicable)

</details>
