### PR TITLE
Fix result image URLs

### DIFF
--- a/src/anomalib/models/cfa/README.md
+++ b/src/anomalib/models/cfa/README.md
@@ -139,11 +139,11 @@ When the numbers are produced, early stopping callback (patience: 5) is used. It
 
 ### Sample Results
 
-![Sample Result 1](../../../docs/source/images/cfa/results/0.png "Sample Result 1")
+![Sample Result 1](../../../../docs/source/images/cfa/results/0.png "Sample Result 1")
 
-![Sample Result 2](../../../docs/source/images/cfa/results/1.png "Sample Result 2")
+![Sample Result 2](../../../../docs/source/images/cfa/results/1.png "Sample Result 2")
 
-![Sample Result 3](../../../docs/source/images/cfa/results/2.png "Sample Result 3")
+![Sample Result 3](../../../../docs/source/images/cfa/results/2.png "Sample Result 3")
 
 ## Reference
 

--- a/src/anomalib/models/cflow/README.md
+++ b/src/anomalib/models/cflow/README.md
@@ -42,8 +42,8 @@ All results gathered with seed `42`.
 
 ### Sample Results
 
-![Sample Result 1](../../../docs/source/images/cflow/results/0.png "Sample Result 1")
+![Sample Result 1](../../../../docs/source/images/cflow/results/0.png "Sample Result 1")
 
-![Sample Result 2](../../../docs/source/images/cflow/results/1.png "Sample Result 2")
+![Sample Result 2](../../../../docs/source/images/cflow/results/1.png "Sample Result 2")
 
-![Sample Result 3](../../../docs/source/images/cflow/results/2.png "Sample Result 3")
+![Sample Result 3](../../../../docs/source/images/cflow/results/2.png "Sample Result 3")

--- a/src/anomalib/models/csflow/README.md
+++ b/src/anomalib/models/csflow/README.md
@@ -93,8 +93,8 @@ All results gathered with seed `42`.
 
 ### Sample Results
 
-![Sample Result 1](../../../docs/source/images/csflow/results/0.png "Sample Result 1")
+![Sample Result 1](../../../../docs/source/images/csflow/results/0.png "Sample Result 1")
 
-![Sample Result 2](../../../docs/source/images/csflow/results/1.png "Sample Result 2")
+![Sample Result 2](../../../../docs/source/images/csflow/results/1.png "Sample Result 2")
 
-![Sample Result 3](../../../docs/source/images/csflow/results/2.png "Sample Result 3")
+![Sample Result 3](../../../../docs/source/images/csflow/results/2.png "Sample Result 3")

--- a/src/anomalib/models/fastflow/README.md
+++ b/src/anomalib/models/fastflow/README.md
@@ -110,8 +110,8 @@ All results gathered with seed `0`.
 
 ### Sample Results
 
-![Sample Result 1](../../../docs/source/images/fastflow/results/0.png "Sample Result 1")
+![Sample Result 1](../../../../docs/source/images/fastflow/results/0.png "Sample Result 1")
 
-![Sample Result 2](../../../docs/source/images/fastflow/results/1.png "Sample Result 2")
+![Sample Result 2](../../../../docs/source/images/fastflow/results/1.png "Sample Result 2")
 
-![Sample Result 3](../../../docs/source/images/fastflow/results/2.png "Sample Result 3")
+![Sample Result 3](../../../../docs/source/images/fastflow/results/2.png "Sample Result 3")

--- a/src/anomalib/models/padim/README.md
+++ b/src/anomalib/models/padim/README.md
@@ -47,8 +47,8 @@ All results gathered with seed `42`.
 
 ### Sample Results
 
-![Sample Result 1](../../../docs/source/images/padim/results/0.png "Sample Result 1")
+![Sample Result 1](../../../../docs/source/images/padim/results/0.png "Sample Result 1")
 
-![Sample Result 2](../../../docs/source/images/padim/results/1.png "Sample Result 2")
+![Sample Result 2](../../../../docs/source/images/padim/results/1.png "Sample Result 2")
 
-![Sample Result 3](../../../docs/source/images/padim/results/2.png "Sample Result 3")
+![Sample Result 3](../../../../docs/source/images/padim/results/2.png "Sample Result 3")

--- a/src/anomalib/models/stfpm/README.md
+++ b/src/anomalib/models/stfpm/README.md
@@ -47,8 +47,8 @@ All results gathered with seed `42`.
 
 ### Sample Results
 
-![Sample Result 1](../../../docs/source/images/stfpm/results/0.png "Sample Result 1")
+![Sample Result 1](../../../../docs/source/images/stfpm/results/0.png "Sample Result 1")
 
-![Sample Result 2](../../../docs/source/images/stfpm/results/1.png "Sample Result 2")
+![Sample Result 2](../../../../docs/source/images/stfpm/results/1.png "Sample Result 2")
 
-![Sample Result 3](../../../docs/source/images/stfpm/results/2.png "Sample Result 3")
+![Sample Result 3](../../../../docs/source/images/stfpm/results/2.png "Sample Result 3")


### PR DESCRIPTION
## Description

The sample result images in the README files for several of the models did not display.

## Changes

The wrong image URLs were corrected. I opted to stick with relative paths as this makes more sense in case of a fork, for example. I did not touch the existing absolute paths.

- [x] Documentation update