### PR TITLE
Refactor/extensions custom dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ dataset:
   normal_test_dir: null # name of the folder containing normal test images.
   task: segmentation # classification or segmentation
   mask: <path/to/mask/annotations> #optional
-  extensions: null
+  extensions: null # .ext or [.ext1, .ext2, ...]
   split_ratio: 0.2 # ratio of the normal images that will be used to create a test split
   image_size: 256
   train_batch_size: 32

--- a/src/anomalib/data/utils/path.py
+++ b/src/anomalib/data/utils/path.py
@@ -58,7 +58,7 @@ def _prepare_files_labels(
     if isinstance(extensions, str):
         extensions = (extensions,)
 
-    assert all(extension[0] == "." for extension in extensions), "All extension names must start with the dot."
+    assert all(extension.startswith(".") for extension in extensions), "All extension names must start with the dot."
 
     filenames = [
         f

--- a/src/anomalib/data/utils/path.py
+++ b/src/anomalib/data/utils/path.py
@@ -58,13 +58,15 @@ def _prepare_files_labels(
     if isinstance(extensions, str):
         extensions = (extensions,)
 
+    assert all(extension[0] == "." for extension in extensions), "All extension names must start with the dot."
+
     filenames = [
         f
         for f in path.glob("**/*")
         if f.suffix in extensions and not f.is_dir() and not any(part.startswith(".") for part in f.parts)
     ]
     if not filenames:
-        raise RuntimeError(f"Found 0 {path_type} images in {path}")
+        raise RuntimeError(f"Found 0 {path_type} images in {path} with extensions {extensions}")
 
     labels = [path_type] * len(filenames)
 

--- a/src/anomalib/data/utils/path.py
+++ b/src/anomalib/data/utils/path.py
@@ -58,7 +58,8 @@ def _prepare_files_labels(
     if isinstance(extensions, str):
         extensions = (extensions,)
 
-    assert all(extension.startswith(".") for extension in extensions), "All extension names must start with the dot."
+    if not all(extension.startswith(".") for extension in extensions):
+        raise RuntimeError(f"All extensions {extensions} must start with the dot")
 
     filenames = [
         f


### PR DESCRIPTION
## Description

With the Custom Dataset, it is not apparent if the `RuntimeError: Found 0 normal images in path/` is caused by the wrong path or by the wrong extensions, as in [this issue](https://github.com/openvinotoolkit/anomalib/issues/1554#issue-2045605889).

## Changes

I suggest adding additional information to this error message, showing the extensions used. Also, I have added another check to see if the names of custom extensions start with the dot and an explanation on how to add custom extensions to the config file.

<details>

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

</details>

## Checklist

<details>
<summary>Ensure that you followed the following</summary>

- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (If applicable)
- [ ] I have made corresponding changes to the documentation (If applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (If applicable)

</details>