### PR TITLE
[Bug] v1: Fix default input normalization method

### DIFF
--- a/src/anomalib/data/depth/folder_3d.py
+++ b/src/anomalib/data/depth/folder_3d.py
@@ -295,7 +295,7 @@ class Folder3D(AnomalibDataModule):
         center_crop (int | tuple[int, int] | None, optional): When provided, the images will be center-cropped to the
             provided dimensions.
             Defaults to ``None``.
-        normalization (str | InputNormalizationMethod): Normalization method to apply to the input images.
+        normalization (InputNormalizationMethod | str): Normalization method to apply to the input images.
             Defaults to ``InputNormalizationMethod.IMAGENET``.
         train_batch_size (int, optional): Training batch size.
             Defaults to ``32``.
@@ -334,7 +334,7 @@ class Folder3D(AnomalibDataModule):
         extensions: tuple[str] | None = None,
         image_size: int | tuple[int, int] = (256, 256),
         center_crop: int | tuple[int, int] | None = None,
-        normalization: str | InputNormalizationMethod = InputNormalizationMethod.IMAGENET,
+        normalization: InputNormalizationMethod | str = InputNormalizationMethod.IMAGENET,
         train_batch_size: int = 32,
         eval_batch_size: int = 32,
         num_workers: int = 8,

--- a/src/anomalib/data/depth/mvtec_3d.py
+++ b/src/anomalib/data/depth/mvtec_3d.py
@@ -213,7 +213,7 @@ class MVTec3D(AnomalibDataModule):
         center_crop (int | tuple[int, int] | None, optional): When provided, the images will be center-cropped to the
             provided dimensions.
             Defaults to ``None``.
-        normalization (str | InputNormalizationMethod): Normalization method to be applied to the input images.
+        normalization (InputNormalizationMethod | str): Normalization method to be applied to the input images.
             Defaults to ``InputNormalizationMethod.IMAGENET``.
         train_batch_size (int, optional): Training batch size.
             Defaults to ``32``.
@@ -245,7 +245,7 @@ class MVTec3D(AnomalibDataModule):
         category: str = "bagel",
         image_size: int | tuple[int, int] = (256, 256),
         center_crop: int | tuple[int, int] | None = None,
-        normalization: str | InputNormalizationMethod = InputNormalizationMethod.IMAGENET,
+        normalization: InputNormalizationMethod | str = InputNormalizationMethod.IMAGENET,
         train_batch_size: int = 32,
         eval_batch_size: int = 32,
         num_workers: int = 8,

--- a/src/anomalib/data/image/btech.py
+++ b/src/anomalib/data/image/btech.py
@@ -191,8 +191,8 @@ class BTech(AnomalibDataModule):
         center_crop (int | tuple[int, int] | None, optional): When provided, the images will be center-cropped to the
             provided dimensions.
             Defaults to ``None``.
-        normalization (str | InputNormalizationMethod, optional): When True, the images will be normalized to the
-            ImageNet statistics.
+        normalization (InputNormalizationMethod | str, optional): Normalization method to be applied to the
+            input images.
             Defaults to ``InputNormalizationMethod.IMAGENET``.
         train_batch_size (int, optional): Training batch size.
             Defaults to ``32``.
@@ -264,7 +264,7 @@ class BTech(AnomalibDataModule):
         category: str = "01",
         image_size: int | tuple[int, int] = (256, 256),
         center_crop: int | tuple[int, int] | None = None,
-        normalization: str | InputNormalizationMethod = InputNormalizationMethod.IMAGENET,
+        normalization: InputNormalizationMethod | str = InputNormalizationMethod.IMAGENET,
         train_batch_size: int = 32,
         eval_batch_size: int = 32,
         num_workers: int = 8,

--- a/src/anomalib/data/image/folder.py
+++ b/src/anomalib/data/image/folder.py
@@ -290,7 +290,7 @@ class Folder(AnomalibDataModule):
         center_crop (int | tuple[int, int] | None, optional): When provided, the images will be center-cropped
             to the provided dimensions.
             Defaults to ``None``.
-        normalization (str | InputNormalizationMethod): Normalization method to apply to the input images.
+        normalization (InputNormalizationMethod | str): Normalization method to apply to the input images.
             Defaults to ``InputNormalizationMethod.IMAGENET``.
         train_batch_size (int, optional): Training batch size.
             Defaults to ``32``.
@@ -384,7 +384,7 @@ class Folder(AnomalibDataModule):
         extensions: tuple[str] | None = None,
         image_size: int | tuple[int, int] = (256, 256),
         center_crop: int | tuple[int, int] | None = None,
-        normalization: str | InputNormalizationMethod = InputNormalizationMethod.IMAGENET,
+        normalization: InputNormalizationMethod | str = InputNormalizationMethod.IMAGENET,
         train_batch_size: int = 32,
         eval_batch_size: int = 32,
         num_workers: int = 8,

--- a/src/anomalib/data/image/kolektor.py
+++ b/src/anomalib/data/image/kolektor.py
@@ -217,7 +217,7 @@ class Kolektor(AnomalibDataModule):
         center_crop (int | tuple[int, int] | None, optional): When provided, the images will be center-cropped
             to the provided dimensions.
             Defaults to ``None``.
-        normalization (str | InputNormalizationMethod): Normalization method to apply to the input images.
+        normalization (InputNormalizationMethod | str): Normalization method to apply to the input images.
             Defaults to ``InputNormalizationMethod.IMAGENET``.
         train_batch_size (int, optional): Training batch size.
             Defaults to ``32``.
@@ -249,7 +249,7 @@ class Kolektor(AnomalibDataModule):
         root: Path | str = "./datasets/kolektor",
         image_size: int | tuple[int, int] = (256, 256),
         center_crop: int | tuple[int, int] | None = None,
-        normalization: str | InputNormalizationMethod = InputNormalizationMethod.IMAGENET,
+        normalization: InputNormalizationMethod | str = InputNormalizationMethod.IMAGENET,
         train_batch_size: int = 32,
         eval_batch_size: int = 32,
         num_workers: int = 8,


### PR DESCRIPTION
## Description
When attempting to train via CLI using the default normalization method on certain datasets (btech, kolektor, folder, mvtech_3d, folder_3d), the following error occurs:

 ```
'IMAGENET' is not a valid InputNormalizationMethod 
```

For example, try executing the following command:

```
anomalib train --model Patchcore --data anomalib.data.Kolektor
```
I changed the order of types from `str | InputNormalizationMethod` to `InputNormalizationMethod | str` to ensure that the default value is interpreted correctly as an instance of the InputNormalizationMethod enum, instead of the string 'IMAGENET'.

- Fixes #1584 

## Changes

<details>
<summary>Describe the changes you made
</summary>

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which refactors the code base)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

</details>

## Checklist

<details>
<summary>Ensure that you followed the following</summary>

- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (If applicable)
- [ ] I have made corresponding changes to the documentation (If applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (If applicable)

</details>
