### PR TITLE
v1 - [Bug] Fix issues when validation and test split modes set to 'none'

### DIFF
--- a/src/anomalib/utils/config.py
+++ b/src/anomalib/utils/config.py
@@ -19,6 +19,8 @@ from jsonargparse import Namespace
 from jsonargparse import Path as JSONArgparsePath
 from omegaconf import DictConfig, ListConfig, OmegaConf
 
+from anomalib.data.utils import ValSplitMode
+
 logger = logging.getLogger(__name__)
 
 
@@ -128,6 +130,7 @@ def update_config(config: DictConfig | ListConfig | Namespace) -> DictConfig | L
     config.results_dir.path = str(project_path)
 
     config = _update_nncf_config(config)
+    config = _update_val_config(config)
 
     # write the original config for eventual debug (modified config at the end of the function)
     (project_path / "config_original.yaml").write_text(to_yaml(config_original))
@@ -217,6 +220,21 @@ def _update_nncf_config(config: DictConfig | ListConfig) -> DictConfig | ListCon
         config.optimization.nncf.input_info.sample_size = [1, 3, *sample_size]
         if config.optimization.nncf.apply and "update_config" in config.optimization.nncf:
             return OmegaConf.merge(config, config.optimization.nncf.update_config)
+    return config
+
+
+def _update_val_config(config: DictConfig | ListConfig) -> DictConfig | ListConfig:
+    """Skip validation if `val_split_mode` is set to 'none'.
+
+    Args:
+        config (DictConfig | ListConfig): Configurable parameters of the current run.
+
+    Returns:
+        DictConfig | ListConfig: Updated configurable parameters in DictConfig object.
+    """
+    if config.data.init_args.val_split_mode == ValSplitMode.NONE and config.trainer.limit_val_batches != 0.0:
+        logger.warning("Running without validation set. Setting trainer.limit_val_batches to 0.")
+        config.trainer.limit_val_batches = 0.0
     return config
 
 


### PR DESCRIPTION
## 📝 Description

These changes follow the logic in the current main branch, where no issues occur when the split modes are set to 'none':

- To skip the validation stage, set `config.trainer.limit_val_batches` to `0.0` when `val_split_mode` is 'NONE' in the `config.py` file.
- To skip the test stage after training, include a conditional check `datamodule.test_split_mode == TestSplitMode.NONE` in the `engine.py` file.

**Note**: I'm not quite sure why those changes were removed in v1, but without those logics, the skipping process is not working properly.

🛠️ Fixes # (issue number)

## ✨ Changes

Select what type of change your PR is:

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
