### PR TITLE
🚀 v1 - Add support for MVTec LOCO dataset and sPRO metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Add support for MVTec LOCO AD dataset by @willyfh in https://github.com/openvinotoolkit/anomalib/pull/1635
+
 ### Changed
 
 - Changed default inference device to AUTO in https://github.com/openvinotoolkit/anomalib/pull/1534

--- a/docs/source/markdown/guides/reference/data/image/index.md
+++ b/docs/source/markdown/guides/reference/data/image/index.md
@@ -30,6 +30,13 @@ Learn more about Kolektor dataset.
 Learn more about MVTec 2D dataset
 :::
 
+:::{grid-item-card} MVTec LOCO
+:link: ./mvtec_loco
+:link-type: doc
+
+Learn more about MVTec LOCO dataset
+:::
+
 :::{grid-item-card} Visa
 :link: ./visa
 :link-type: doc
@@ -47,5 +54,6 @@ Learn more about Visa dataset.
 ./folder
 ./kolektor
 ./mvtec
+./mvtec_loco
 ./visa
 ```

--- a/docs/source/markdown/guides/reference/data/image/mvtec_loco.md
+++ b/docs/source/markdown/guides/reference/data/image/mvtec_loco.md
@@ -1,0 +1,7 @@
+# MVTec LOCO Data
+
+```{eval-rst}
+.. automodule:: anomalib.data.image.mvtec_loco
+   :members:
+   :show-inheritance:
+```

--- a/src/anomalib/callbacks/metrics.py
+++ b/src/anomalib/callbacks/metrics.py
@@ -67,8 +67,7 @@ class _MetricsCallback(Callback):
             pl_module (AnomalyModule): Anomalib Model that inherits pl LightningModule.
             stage (str | None, optional): fit, validate, test or predict. Defaults to None.
         """
-        del trainer, stage  # These variables are not used.
-
+        del stage  # this variable is not used.
         image_metric_names = [] if self.image_metric_names is None else self.image_metric_names
         if isinstance(image_metric_names, str):
             image_metric_names = [image_metric_names]
@@ -92,6 +91,8 @@ class _MetricsCallback(Callback):
             pl_module.image_metrics = create_metric_collection(image_metric_names, "image_")
             pl_module.pixel_metrics = create_metric_collection(pixel_metric_names, "pixel_")
             self._set_threshold(pl_module)
+            if hasattr(trainer.datamodule, "saturation_config"):
+                self._set_saturation_config(pl_module, trainer.datamodule.saturation_config)
 
     def on_validation_epoch_start(
         self,
@@ -165,6 +166,9 @@ class _MetricsCallback(Callback):
     def _set_threshold(self, pl_module: AnomalyModule) -> None:
         pl_module.image_metrics.set_threshold(pl_module.image_threshold.value.item())
         pl_module.pixel_metrics.set_threshold(pl_module.pixel_threshold.value.item())
+
+    def _set_saturation_config(self, pl_module: AnomalyModule, saturation_config: dict[int, Any]) -> None:
+        pl_module.pixel_metrics.set_saturation_config(saturation_config)
 
     def _update_metrics(
         self,

--- a/src/anomalib/callbacks/metrics.py
+++ b/src/anomalib/callbacks/metrics.py
@@ -180,7 +180,11 @@ class _MetricsCallback(Callback):
         image_metric.update(output["pred_scores"], output["label"].int())
         if "mask" in output and "anomaly_maps" in output:
             pixel_metric.to(self.device)
-            pixel_metric.update(torch.squeeze(output["anomaly_maps"]), torch.squeeze(output["mask"].int()))
+            pixel_metric.update(
+                torch.squeeze(output["anomaly_maps"]),
+                torch.squeeze(output["mask"].int()),
+                masks=torch.squeeze(output["masks"]) if "masks" in output else None,
+            )
 
     def _outputs_to_device(self, output: STEP_OUTPUT) -> STEP_OUTPUT | dict[str, Any]:
         if isinstance(output, dict):

--- a/src/anomalib/data/__init__.py
+++ b/src/anomalib/data/__init__.py
@@ -15,7 +15,7 @@ from anomalib.utils.config import to_tuple
 
 from .base import AnomalibDataModule, AnomalibDataset
 from .depth import DepthDataFormat, Folder3D, MVTec3D
-from .image import BTech, Folder, ImageDataFormat, Kolektor, MVTec, Visa
+from .image import BTech, Folder, ImageDataFormat, Kolektor, MVTec, MVTecLoco, Visa
 from .predict import PredictDataset
 from .video import Avenue, ShanghaiTech, UCSDped, VideoDataFormat
 
@@ -62,6 +62,7 @@ __all__ = [
     "Kolektor",
     "MVTec",
     "MVTec3D",
+    "MVTecLoco",
     "Avenue",
     "UCSDped",
     "ShanghaiTech",

--- a/src/anomalib/data/base/datamodule.py
+++ b/src/anomalib/data/base/datamodule.py
@@ -164,6 +164,9 @@ class AnomalibDataModule(LightningDataModule, ABC):
             # converted from random training sample
             self.train_data, normal_val_data = random_split(self.train_data, self.val_split_ratio, seed=self.seed)
             self.val_data = SyntheticAnomalyDataset.from_dataset(normal_val_data)
+        elif self.val_split_mode == ValSplitMode.FROM_DIR:
+            # the val_data is prepared in subclass
+            pass
         elif self.val_split_mode != ValSplitMode.NONE:
             msg = f"Unknown validation split mode: {self.val_split_mode}"
             raise ValueError(msg)

--- a/src/anomalib/data/image/__init__.py
+++ b/src/anomalib/data/image/__init__.py
@@ -13,6 +13,7 @@ from .btech import BTech
 from .folder import Folder
 from .kolektor import Kolektor
 from .mvtec import MVTec
+from .mvtec_loco import MVTecLoco
 from .visa import Visa
 
 
@@ -21,6 +22,7 @@ class ImageDataFormat(str, Enum):
 
     MVTEC = "mvtec"
     MVTEC_3D = "mvtec_3d"
+    MVTEC_LOCO = "mvtec_loco"
     BTECH = "btech"
     KOLEKTOR = "kolektor"
     FOLDER = "folder"
@@ -28,4 +30,4 @@ class ImageDataFormat(str, Enum):
     VISA = "visa"
 
 
-__all__ = ["BTech", "Folder", "Kolektor", "MVTec", "Visa"]
+__all__ = ["BTech", "Folder", "Kolektor", "MVTec", "MVTecLoco", "Visa"]

--- a/src/anomalib/data/image/mvtec_loco.py
+++ b/src/anomalib/data/image/mvtec_loco.py
@@ -98,13 +98,10 @@ def _merge_gt_mask(
                 mask = cv2.imread(str(mask_file), cv2.IMREAD_UNCHANGED)
                 if merged_mask is None:
                     merged_mask = np.zeros_like(mask)
-                merged_mask = np.maximum(merged_mask, mask)
+                merged_mask += mask
 
         if merged_mask is None:
             continue
-
-        # Binarize masks
-        merged_mask = np.where(merged_mask > 0, 255, 0)
 
         # Define the path for the new merged mask
         _, anomaly_dir, image_filename = mask_path.parts[-3:]

--- a/src/anomalib/data/image/mvtec_loco.py
+++ b/src/anomalib/data/image/mvtec_loco.py
@@ -338,9 +338,9 @@ class MVTecLocoDataset(AnomalibDataset):
     def __getitem__(self, index: int) -> dict[str, str | torch.Tensor]:
         """Get dataset item for the index ``index``.
 
-        The implementation of this method is mostly based on the parent's class implementation, with some different as follows:
+        This method is mostly based on the super class implementation, with some different as follows:
             - Using 'torch.where' to make sure the 'mask' in the return item is binarized
-            - An additional 'masks' is added to pass the non-binary masks with original size for the sPRO metric calculation
+            - An additional 'masks' is added, the non-binary masks with original size for the sPRO metric calculation
         Args:
             index (int): Index to get the item.
 

--- a/src/anomalib/data/image/mvtec_loco.py
+++ b/src/anomalib/data/image/mvtec_loco.py
@@ -100,8 +100,11 @@ def _merge_gt_mask(
                     merged_mask = np.zeros_like(mask)
                 merged_mask = np.maximum(merged_mask, mask)
 
+        if merged_mask is None:
+            continue
+
         # Binarize masks
-        merged_mask = np.minimum(merged_mask, 255)
+        merged_mask = np.where(merged_mask > 0, 255, 0)
 
         # Define the path for the new merged mask
         _, anomaly_dir, image_filename = mask_path.parts[-3:]

--- a/src/anomalib/data/image/mvtec_loco.py
+++ b/src/anomalib/data/image/mvtec_loco.py
@@ -105,7 +105,7 @@ def _merge_gt_mask(
 
         # Define the path for the new merged mask
         _, anomaly_dir, image_filename = mask_path.parts[-3:]
-        new_mask_path = root / Path(gt_merged_dir) / anomaly_dir / (image_filename + ".png")
+        new_mask_path = root / gt_merged_dir / anomaly_dir / (image_filename + ".png")
 
         # Create the necessary directories if they do not exist
         new_mask_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/anomalib/data/image/mvtec_loco.py
+++ b/src/anomalib/data/image/mvtec_loco.py
@@ -134,7 +134,7 @@ def make_mvtec_loco_dataset(
     +---+---------------+-------+---------+---------------+---------------------------------------+-------------+
     |   | path          | split | label   | image_path    | mask_path                             | label_index |
     +===+===============+=======+=========+===============+=======================================+=============+
-    | 0 | datasets/name | test  | defect  | filename.png  | path/to/merged_masks/filename.png      | 1           |
+    | 0 | datasets/name | test  | defect  | filename.png  | path/to/merged_masks/filename.png     | 1           |
     +---+---------------+-------+---------+---------------+---------------------------------------+-------------+
 
     Note: the final image_path is converted to full path by combining it with the path, split, and label columns

--- a/src/anomalib/data/image/mvtec_loco.py
+++ b/src/anomalib/data/image/mvtec_loco.py
@@ -16,9 +16,11 @@ References:
       in: International Journal of Computer Vision (IJCV) 130, 947-969, 2022, DOI: 10.1007/s11263-022-01578-9
 """
 
+import json
 import logging
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 import albumentations as A  # noqa: N812
 import cv2
@@ -62,6 +64,41 @@ CATEGORIES = (
 )
 
 GT_MERGED_DIR = "ground_truth_merged"
+
+SATURATION_CONFIG_FILENAME = "defects_config.json"
+
+
+def load_saturation_config(config_path: str | Path) -> dict[int, Any]:
+    """Load saturation configurations from a JSON file.
+
+    Args:
+        config_path (str | Path): Path to the saturation configuration file.
+
+    Returns:
+        Dict: A dictionary with pixel values as keys and the corresponding configurations as values.
+
+    Example JSON format in the file:
+    [
+        {
+            "defect_name": "1_additional_pushpin",
+            "pixel_value": 255,
+            "saturation_threshold": 6300,
+            "relative_saturation": false
+        },
+        {
+            "defect_name": "2_additional_pushpins",
+            "pixel_value": 254,
+            "saturation_threshold": 12600,
+            "relative_saturation": false
+        },
+        ...
+    ]
+    """
+    with Path.open(Path(config_path)) as file:
+        configs = json.load(file)
+
+    # Create a dictionary with pixel values as keys
+    return {conf["pixel_value"]: conf for conf in configs}
 
 
 def _merge_gt_mask(
@@ -448,9 +485,10 @@ class MVTecLoco(AnomalibDataModule):
             val_split_ratio=val_split_ratio,
             seed=seed,
         )
-
+        self.saturation_config: dict[int, Any]
         self.root = Path(root)
         self.category = Path(category)
+        self.saturation_config = {}
 
         transform_train = get_transforms(
             config=transform_config_train,
@@ -533,7 +571,7 @@ class MVTecLoco(AnomalibDataModule):
             download_and_extract(self.root, DOWNLOAD_INFO)
 
     def _setup(self, _stage: str | None = None) -> None:
-        """Set up the datasets and perform dynamic subset splitting.
+        """Set up the datasets, configs, and perform dynamic subset splitting.
 
         This method overrides the parent class's method to also setup the val dataset.
         The MVTec LOCO dataset provides an independent validation subset.
@@ -548,3 +586,6 @@ class MVTecLoco(AnomalibDataModule):
 
         self._create_test_split()
         self._create_val_split()
+
+        saturation_path = self.root / self.category / SATURATION_CONFIG_FILENAME
+        self.saturation_config = load_saturation_config(saturation_path)

--- a/src/anomalib/data/image/mvtec_loco.py
+++ b/src/anomalib/data/image/mvtec_loco.py
@@ -1,0 +1,499 @@
+"""MVTec LOCO AD Dataset (CC BY-NC-SA 4.0).
+
+Description:
+    This script contains PyTorch Dataset, Dataloader and PyTorch Lightning
+    DataModule for the MVTec LOCO AD dataset. If the dataset is not on the file system,
+    the script downloads and extracts the dataset and create PyTorch data objects.
+
+License:
+    MVTec LOCO AD dataset is released under the Creative Commons
+    Attribution-NonCommercial-ShareAlike 4.0 International License
+    (CC BY-NC-SA 4.0)(https://creativecommons.org/licenses/by-nc-sa/4.0/).
+
+References:
+    - Paul Bergmann, Kilian Batzner, Michael Fauser, David Sattlegger, and Carsten Steger:
+      Beyond Dents and Scratches: Logical Constraints in Unsupervised Anomaly Detection and Localization;
+      in: International Journal of Computer Vision (IJCV) 130, 947-969, 2022, DOI: 10.1007/s11263-022-01578-9
+"""
+
+import logging
+from collections.abc import Sequence
+from pathlib import Path
+
+import albumentations as A  # noqa: N812
+import cv2
+import numpy as np
+from pandas import DataFrame
+
+from anomalib import TaskType
+from anomalib.data.base import AnomalibDataModule, AnomalibDataset
+from anomalib.data.utils import (
+    DownloadInfo,
+    InputNormalizationMethod,
+    LabelName,
+    Split,
+    TestSplitMode,
+    ValSplitMode,
+    download_and_extract,
+    get_transforms,
+)
+
+logger = logging.getLogger(__name__)
+
+
+IMG_EXTENSIONS = (".png", ".PNG")
+
+DOWNLOAD_INFO = DownloadInfo(
+    name="mvtec_loco",
+    url="https://www.mydrive.ch/shares/48237/1b9106ccdfbb09a0c414bd49fe44a14a/download/430647091-1646842701"
+    "/mvtec_loco_anomaly_detection.tar.xz",
+    checksum="d40f092ac6f88433f609583c4a05f56f",
+)
+
+CATEGORIES = (
+    "breakfast_box",
+    "juice_bottle",
+    "pushpins",
+    "screw_bag",
+    "splicing_connectors",
+)
+
+GT_MERGED_DIR = "ground_truth_merged"
+
+
+def _merge_gt_mask(
+    root: str | Path,
+    extensions: Sequence[str] = IMG_EXTENSIONS,
+    gt_merged_dir: str | Path = GT_MERGED_DIR,
+) -> None:
+    """Merges ground truth masks within specified directories and saves the merged masks.
+
+    Args:
+        root (str | Path): Root directory containing the 'ground_truth' folder.
+        extensions (Sequence[str]): Allowed file extensions for ground truth masks.
+                                    Default is IMG_EXTENSIONS.
+        gt_merged_dir (str | Path]): Directory where merged masks will be saved.
+                                     Default is GT_MERGED_DIR.
+
+    Returns:
+        None
+
+    Example:
+        >>> _merge_gt_mask('path/to/breakfast_box/')
+
+        This function reads ground truth masks from the specified directories, merges them into
+        a single mask for each corresponding images (e.g. merge 059/000.png and 059/001.png into 059.png),
+        and saves the merged masks in the default GT_MERGED_DIR directory.
+
+        Note: The merged masks are saved with the same filename structure as the corresponding anomalous image files.
+    """
+    root = Path(root)
+    gt_mask_paths = {f.parent for f in root.glob("ground_truth/**/*") if f.suffix in extensions}
+
+    for mask_path in gt_mask_paths:
+        # Merge each mask inside mask_path into a single mask
+        merged_mask = None
+        for mask_file in mask_path.glob("*"):
+            if mask_file.suffix in extensions:
+                mask = cv2.imread(str(mask_file), cv2.IMREAD_UNCHANGED)
+                if merged_mask is None:
+                    merged_mask = np.zeros_like(mask)
+                merged_mask = np.maximum(merged_mask, mask)
+
+        # Binarize masks
+        merged_mask = np.minimum(merged_mask, 255)
+
+        # Define the path for the new merged mask
+        _, anomaly_dir, image_filename = mask_path.parts[-3:]
+        new_mask_path = root / Path(gt_merged_dir) / anomaly_dir / (image_filename + ".png")
+
+        # Create the necessary directories if they do not exist
+        new_mask_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Save the merged mask
+        cv2.imwrite(str(new_mask_path), merged_mask)
+
+
+def make_mvtec_loco_dataset(
+    root: str | Path,
+    split: str | Split | None = None,
+    extensions: Sequence[str] = IMG_EXTENSIONS,
+    gt_merged_dir: str | Path = GT_MERGED_DIR,
+) -> DataFrame:
+    """Create MVTec LOCO AD samples by parsing the original MVTec LOCO AD data file structure.
+
+    The files are expected to follow the structure:
+        path/to/dataset/split/category/image_filename.png
+        path/to/dataset/ground_truth/category/image_filename/000.png
+
+    where there can be multiple ground-truth masks for the corresponding anomalous images.
+
+    This function first merges the multiple ground-truth-masks by executing _merge_gt_mask(),
+    it then creates a dataframe to store the parsed information based on the following format:
+
+    +---+---------------+-------+---------+---------------+---------------------------------------+-------------+
+    |   | path          | split | label   | image_path    | mask_path                             | label_index |
+    +===+===============+=======+=========+===============+=======================================+=============+
+    | 0 | datasets/name | test  | defect  | filename.png  | path/to/merged_masks/filename.png      | 1           |
+    +---+---------------+-------+---------+---------------+---------------------------------------+-------------+
+
+    Note: the final image_path is converted to full path by combining it with the path, split, and label columns
+    Example, datasets/name/test/defect/filename.png
+
+    Args:
+        root (str | Path): Path to dataset
+        split (str | Split | None): Dataset split (ie., either train or test).
+            Defaults to ``None``.
+        extensions (Sequence[str]): List of file extensions to be included in the dataset.
+            Defaults to ``None``.
+        gt_merged_dir (str | Path]): Directory where merged masks will be saved.
+                                             Default is GT_MERGED_DIR.
+
+    Returns:
+        DataFrame: an output dataframe containing the samples of the dataset.
+
+    Examples:
+        The following example shows how to get test samples from MVTec LOCO AD pushpins category:
+
+        >>> root = Path('./MVTec_LOCO')
+        >>> category = 'pushpins'
+        >>> path = root / category
+        >>> samples = make_mvtec_loco_dataset(path, split='test')
+    """
+    root = Path(root)
+    gt_merged_dir = Path(gt_merged_dir)
+
+    # assert the directory to store the merged ground-truth masks is different than the original gt directory
+    assert gt_merged_dir != "ground_truth"
+
+    # Merge ground-truth masks for each corresponding images and store into the 'gt_merged_dir' folder
+    if (root / gt_merged_dir).is_dir():
+        logger.info(f"Found the directory of the merged ground-truth masks: {root / gt_merged_dir!s}")
+    else:
+        logger.info("Merging the multiple ground-truth masks for each corresponding images.")
+        _merge_gt_mask(root, gt_merged_dir=gt_merged_dir)
+
+    # Retrieve the image and mask files
+    samples_list = []
+    for f in root.glob("**/*"):
+        if f.suffix in extensions:
+            parts = f.parts
+            # Ignore original 'ground_truth' folder because the 'gt_merged_dir' is used instead
+            if "ground_truth" not in parts:
+                split_folder, label_folder, image_path = parts[-3:]
+                samples_list.append((str(root), split_folder, label_folder, image_path))
+
+    if not samples_list:
+        msg = f"Found 0 images in {root}"
+        raise RuntimeError(msg)
+
+    samples = DataFrame(samples_list, columns=["path", "split", "label", "image_path"])
+
+    # Modify image_path column by converting to absolute path
+    samples["image_path"] = samples.path + "/" + samples.split + "/" + samples.label + "/" + samples.image_path
+
+    # Replace validation to Split.VAL.value in the split column
+    samples["split"] = samples["split"].replace("validation", Split.VAL.value)
+
+    # Create label index for normal (0) and anomalous (1) images.
+    samples.loc[(samples.label == "good"), "label_index"] = LabelName.NORMAL
+    samples.loc[(samples.label != "good"), "label_index"] = LabelName.ABNORMAL
+    samples.label_index = samples.label_index.astype(int)
+
+    # separate masks from samples
+    mask_samples = samples.loc[samples.split == str(gt_merged_dir)].sort_values(by="image_path", ignore_index=True)
+    samples = samples[samples.split != str(gt_merged_dir)].sort_values(by="image_path", ignore_index=True)
+
+    # assign mask paths to anomalous test images
+    samples["mask_path"] = ""
+    samples.loc[
+        (samples.split == "test") & (samples.label_index == LabelName.ABNORMAL),
+        "mask_path",
+    ] = mask_samples.image_path.to_numpy()
+
+    # assert that the right mask files are associated with the right test images
+    if len(samples.loc[samples.label_index == LabelName.ABNORMAL]):
+        assert (
+            samples.loc[samples.label_index == LabelName.ABNORMAL]
+            .apply(lambda x: Path(x.image_path).stem in Path(x.mask_path).stem, axis=1)
+            .all()
+        ), f"Mismatch between anomalous images and ground truth masks. Make sure the mask files in '{gt_merged_dir!s}' \
+                folder follow the same naming convention as the anomalous images in the dataset (e.g. image: \
+                '000.png', mask: '000.png')."
+
+    if split:
+        samples = samples[samples.split == split].reset_index(drop=True)
+
+    return samples
+
+
+class MVTecLocoDataset(AnomalibDataset):
+    """MVTec LOCO dataset class.
+
+    Args:
+        task (TaskType): Task type, ``classification``, ``detection`` or ``segmentation``.
+        transform (A.Compose): Albumentations Compose object describing the transforms that are applied to the inputs.
+        root (Path | str): Path to the root of the dataset.
+            Defaults to ``./datasets/MVTec_LOCO``.
+        category (str): Sub-category of the dataset, e.g. 'breakfast_box'
+            Defaults to ``breakfast_box``.
+        split (str | Split | None): Split of the dataset, Split.TRAIN, Split.VAL, or Split.TEST
+            Defaults to ``None``.
+
+    Examples:
+        .. code-block:: python
+
+            from anomalib.data.image.mvtec_loco import MVTecLocoDataset
+            from anomalib.data.utils.transforms import get_transforms
+
+            transform = get_transforms(image_size=256)
+            dataset = MVTecLocoDataset(
+                task="classification",
+                transform=transform,
+                root='./datasets/MVTec_LOCO',
+                category='breakfast_box',
+            )
+            dataset.setup()
+            print(dataset[0].keys())
+            # Output: dict_keys(['image_path', 'label', 'image'])
+
+        When the task is segmentation, the dataset will also contain the mask:
+
+        .. code-block:: python
+
+            dataset.task = "segmentation"
+            dataset.setup()
+            print(dataset[0].keys())
+            # Output: dict_keys(['image_path', 'label', 'image', 'mask_path', 'mask'])
+
+        The image is a torch tensor of shape (C, H, W) and the mask is a torch tensor of shape (H, W).
+
+        .. code-block:: python
+
+            print(dataset[0]["image"].shape, dataset[0]["mask"].shape)
+            # Output: (torch.Size([3, 256, 256]), torch.Size([256, 256]))
+    """
+
+    def __init__(
+        self,
+        task: TaskType,
+        transform: A.Compose,
+        root: Path | str = "./datasets/MVTec_LOCO",
+        category: str = "breakfast_box",
+        split: str | Split | None = None,
+    ) -> None:
+        super().__init__(task=task, transform=transform)
+
+        self.root_category = Path(root) / Path(category)
+        self.split = split
+
+    def _setup(self) -> None:
+        self.samples = make_mvtec_loco_dataset(
+            self.root_category,
+            split=self.split,
+            extensions=IMG_EXTENSIONS,
+            gt_merged_dir=GT_MERGED_DIR,
+        )
+
+
+class MVTecLoco(AnomalibDataModule):
+    """MVTec LOCO Datamodule.
+
+    Args:
+        root (Path | str): Path to the root of the dataset.
+            Defaults to ``"./datasets/MVTec_LOCO"``.
+        category (str): Category of the MVTec LOCO dataset (e.g. "breakfast_box").
+            Defaults to ``"breakfast_box"``.
+        image_size (int | tuple[int, int] | None, optional): Size of the input image.
+            Defaults to ``(256, 256)``.
+        center_crop (int | tuple[int, int] | None, optional): When provided, the images will be center-cropped
+            to the provided dimensions.
+            Defaults to ``None``.
+        normalization (InputNormalizationMethod | str): Normalization method to be applied to the input images.
+            Defaults to ``InputNormalizationMethod.IMAGENET``.
+        train_batch_size (int, optional): Training batch size.
+            Defaults to ``32``.
+        eval_batch_size (int, optional): Test batch size.
+            Defaults to ``32``.
+        num_workers (int, optional): Number of workers.
+            Defaults to ``8``.
+        task TaskType): Task type, 'classification', 'detection' or 'segmentation'
+            Defaults to ``TaskType.SEGMENTATION``.
+        transform_config_train (str | A.Compose | None, optional): Config for pre-processing during training.
+            Defaults to ``None``.
+        transform_config_val (str | A.Compose | None, optional): Config for pre-processing
+            during validation.
+            Defaults to ``None``.
+        test_split_mode (TestSplitMode): Setting that determines how the testing subset is obtained.
+            Defaults to ``TestSplitMode.FROM_DIR``.
+        test_split_ratio (float): Fraction of images from the train set that will be reserved for testing.
+            Defaults to ``0.2``.
+        val_split_mode (ValSplitMode): Setting that determines how the validation subset is obtained.
+            Defaults to ``ValSplitMode.FROM_DIR``.
+        val_split_ratio (float): Fraction of train or test images that will be reserved for validation.
+            Defaults to ``0.5``.
+        seed (int | None, optional): Seed which may be set to a fixed value for reproducibility.
+            Defaults to ``None``.
+
+    Examples:
+        To create an MVTec LOCO AD datamodule with default settings:
+
+        >>> datamodule = MVTecLoco(root="anomalib/datasets/MVTec_LOCO")
+        >>> datamodule.setup()
+        >>> i, data = next(enumerate(datamodule.train_dataloader()))
+        >>> data.keys()
+        dict_keys(['image_path', 'label', 'image', 'mask_path', 'mask'])
+
+        >>> data["image"].shape
+        torch.Size([32, 3, 256, 256])
+
+        To change the category of the dataset:
+
+        >>> datamodule = MVTecLoco(category="pushpins")
+
+        To change the image and batch size:
+
+        >>> datamodule = MVTecLoco(image_size=(512, 512), train_batch_size=16, eval_batch_size=8)
+
+        MVTec LOCO AD dataset provide an independent validation set with normal images only in the 'validation' folder.
+        If you would like to use a different validation set splitted from train or test set,
+        you can use the ``val_split_mode`` and ``val_split_ratio`` arguments to create a new validation set.
+
+        >>> datamodule = MVTecLoco(val_split_mode=ValSplitMode.FROM_TEST, val_split_ratio=0.1)
+
+        This will subsample the test set by 10% and use it as the validation set.
+        If you would like to create a validation set synthetically that would
+        not change the test set, you can use the ``ValSplitMode.SYNTHETIC`` option.
+
+        >>> datamodule = MVTecLoco(val_split_mode=ValSplitMode.SYNTHETIC, val_split_ratio=0.2)
+    """
+
+    def __init__(
+        self,
+        root: Path | str = "./datasets/MVTec_LOCO",
+        category: str = "breakfast_box",
+        image_size: int | tuple[int, int] = (256, 256),
+        center_crop: int | tuple[int, int] | None = None,
+        normalization: InputNormalizationMethod | str = InputNormalizationMethod.IMAGENET,
+        train_batch_size: int = 32,
+        eval_batch_size: int = 32,
+        num_workers: int = 8,
+        task: TaskType = TaskType.SEGMENTATION,
+        transform_config_train: str | A.Compose | None = None,
+        transform_config_eval: str | A.Compose | None = None,
+        test_split_mode: TestSplitMode = TestSplitMode.FROM_DIR,
+        test_split_ratio: float = 0.2,
+        val_split_mode: ValSplitMode = ValSplitMode.FROM_DIR,
+        val_split_ratio: float = 0.5,
+        seed: int | None = None,
+    ) -> None:
+        super().__init__(
+            train_batch_size=train_batch_size,
+            eval_batch_size=eval_batch_size,
+            num_workers=num_workers,
+            test_split_mode=test_split_mode,
+            test_split_ratio=test_split_ratio,
+            val_split_mode=val_split_mode,
+            val_split_ratio=val_split_ratio,
+            seed=seed,
+        )
+
+        self.root = Path(root)
+        self.category = Path(category)
+
+        transform_train = get_transforms(
+            config=transform_config_train,
+            image_size=image_size,
+            center_crop=center_crop,
+            normalization=InputNormalizationMethod(normalization),
+        )
+        transform_eval = get_transforms(
+            config=transform_config_eval,
+            image_size=image_size,
+            center_crop=center_crop,
+            normalization=InputNormalizationMethod(normalization),
+        )
+
+        self.train_data = MVTecLocoDataset(
+            task=task,
+            transform=transform_train,
+            split=Split.TRAIN,
+            root=root,
+            category=category,
+        )
+        self.val_data = MVTecLocoDataset(
+            task=task,
+            transform=transform_eval,
+            split=Split.VAL,
+            root=root,
+            category=category,
+        )
+        self.test_data = MVTecLocoDataset(
+            task=task,
+            transform=transform_eval,
+            split=Split.TEST,
+            root=root,
+            category=category,
+        )
+
+    def prepare_data(self) -> None:
+        """Download the dataset if not available.
+
+        This method checks if the specified dataset is available in the file system.
+        If not, it downloads and extracts the dataset into the appropriate directory.
+
+        Example:
+            Assume the dataset is not available on the file system.
+            Here's how the directory structure looks before and after calling the
+            `prepare_data` method:
+
+            Before:
+
+            .. code-block:: bash
+
+                $ tree datasets
+                datasets
+                ├── dataset1
+                └── dataset2
+
+            Calling the method:
+
+            .. code-block:: python
+
+                >> datamodule = MVTecLoco(root="./datasets/MVTec_LOCO", category="breakfast_box")
+                >> datamodule.prepare_data()
+
+            After:
+
+            .. code-block:: bash
+
+                $ tree datasets
+                datasets
+                ├── dataset1
+                ├── dataset2
+                └── MVTec_LOCO
+                    ├── breakfast_box
+                    ├── ...
+                    └── splicing_connectors
+        """
+        if (self.root / self.category).is_dir():
+            logger.info("Found the dataset.")
+        else:
+            download_and_extract(self.root, DOWNLOAD_INFO)
+
+    def _setup(self, _stage: str | None = None) -> None:
+        """Set up the datasets and perform dynamic subset splitting.
+
+        This method overrides the parent class's method to also setup the val dataset.
+        The MVTec LOCO dataset provides an independent validation subset.
+        """
+        assert self.train_data is not None
+        assert self.val_data is not None
+        assert self.test_data is not None
+
+        self.train_data.setup()
+        self.val_data.setup()
+        self.test_data.setup()
+
+        self._create_test_split()
+        self._create_val_split()

--- a/src/anomalib/data/utils/split.py
+++ b/src/anomalib/data/utils/split.py
@@ -49,6 +49,7 @@ class ValSplitMode(str, Enum):
     SAME_AS_TEST = "same_as_test"
     FROM_TEST = "from_test"
     SYNTHETIC = "synthetic"
+    FROM_DIR = "from_dir"
 
 
 def concatenate_datasets(datasets: Sequence["data.AnomalibDataset"]) -> "data.AnomalibDataset":

--- a/src/anomalib/metrics/__init__.py
+++ b/src/anomalib/metrics/__init__.py
@@ -19,6 +19,7 @@ from .auroc import AUROC
 from .collection import AnomalibMetricCollection
 from .min_max import MinMax
 from .pro import PRO
+from .spro import sPRO
 from .threshold import F1AdaptiveThreshold, ManualThreshold
 
 __all__ = [
@@ -30,6 +31,7 @@ __all__ = [
     "ManualThreshold",
     "MinMax",
     "PRO",
+    "sPRO",
 ]
 
 logger = logging.getLogger(__name__)

--- a/src/anomalib/metrics/collection.py
+++ b/src/anomalib/metrics/collection.py
@@ -3,7 +3,11 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+
 from torchmetrics import MetricCollection
+
+logger = logging.getLogger(__name__)
 
 
 class AnomalibMetricCollection(MetricCollection):
@@ -11,8 +15,10 @@ class AnomalibMetricCollection(MetricCollection):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+        self._saturation_config: dict
         self._update_called = False
         self._threshold = 0.5
+        self._saturation_config = {}
 
     def set_threshold(self, threshold_value: float) -> None:
         """Update the threshold value for all metrics that have the threshold attribute."""
@@ -20,6 +26,18 @@ class AnomalibMetricCollection(MetricCollection):
         for metric in self.values():
             if hasattr(metric, "threshold"):
                 metric.threshold = threshold_value
+
+    def set_saturation_config(self, saturation_config: dict) -> None:
+        """Update the saturation config values for all metrics that have the saturation config attribute."""
+        self._saturation_config = saturation_config
+        for name, metric in self.items():
+            if hasattr(metric, "saturation_config"):
+                metric.saturation_config = saturation_config
+            else:
+                logger.warning(
+                    f"Metric {name} may not be suitable for a dataset with the region separated"
+                    "in multiple ground-truth masks.",
+                )
 
     def update(self, *args, **kwargs) -> None:
         """Add data to the metrics."""

--- a/src/anomalib/metrics/spro.py
+++ b/src/anomalib/metrics/spro.py
@@ -126,7 +126,7 @@ def spro_score(predictions: torch.Tensor, targets: torch.Tensor,
             if len(saturation_config) > 0:
                 # Adjust saturation threshold based on configuration
                 saturation_per_label = saturation_config[label.int().item()]
-                saturation_threshold = torch.minimum(saturation_per_label["saturation_threshold"], defect_areas)
+                saturation_threshold = torch.minimum(torch.tensor(saturation_per_label["saturation_threshold"]), defect_areas)
                 if saturation_per_label["relative_saturation"]:
                     saturation_threshold *= defect_areas
             else:

--- a/src/anomalib/metrics/spro.py
+++ b/src/anomalib/metrics/spro.py
@@ -1,0 +1,142 @@
+"""Implementation of sPRO metric based on TorchMetrics."""
+
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import torch
+from torchmetrics import Metric
+from torchmetrics.functional import recall
+from torchmetrics.utilities.data import dim_zero_cat
+
+from anomalib.utils.cv import connected_components_cpu, connected_components_gpu
+
+logger = logging.getLogger(__name__)
+
+class sPRO(Metric):
+    """Saturated Per-Region Overlap (sPRO) Score.
+
+    This metric computes the macro average of the saturated per-region overlap between the
+    predicted anomaly masks and the ground truth masks.
+
+    Args:
+        threshold (float): Threshold used to binarize the predictions.
+            Defaults to ``0.5``.
+        kwargs: Additional arguments to the TorchMetrics base class.
+
+    Example:
+        Import the metric from the package:
+
+        >>> import torch
+        >>> from anomalib.metrics import sPRO
+
+        Create random ``preds`` and ``labels`` tensors:
+
+        >>> labels = torch.randint(low=0, high=2, size=(1, 10, 5), dtype=torch.float32)
+        >>> preds = torch.rand_like(labels)
+
+        Compute the sPRO score for labels and preds:
+
+        >>> spro = sPRO(threshold=0.5)
+        >>> spro.update(preds, _, labels)
+        >>> spro.compute()
+        tensor(0.6333)
+
+        .. note::
+            Note that the example above shows random predictions and labels.
+            Therefore, the sPRO score above may not be reproducible.
+
+    """
+
+    targets: list[torch.Tensor]
+    preds: list[torch.Tensor]
+    saturation_config: dict
+
+    def __init__(self, threshold: float = 0.5, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.threshold = threshold
+        self.saturation_config = {}
+        self.add_state("preds", default=[], dist_reduce_fx="cat")
+        self.add_state("targets", default=[], dist_reduce_fx="cat")
+
+    def update(self, predictions: torch.Tensor, _: torch.Tensor, masks: torch.Tensor) -> None:
+        """Compute the sPRO score for the current batch.
+
+        Args:
+            predictions (torch.Tensor): Predicted anomaly masks
+            _ (torch.Tensor): Unused argument, but needed for different metrics within the same AnomalibMetricCollection
+            masks (torch.Tensor): Ground truth anomaly masks with non-binary values and, original height and width
+
+        Example:
+            To update the metric state for the current batch, use the ``update`` method:
+
+            >>> spro.update(preds, _, labels)
+        """
+        assert masks is not None
+        self.targets.append(masks)
+        self.preds.append(predictions)
+
+    def compute(self) -> torch.Tensor:
+        """Compute the macro average of the sPRO score across all masks in all batches.
+
+        Example:
+            To compute the metric based on the state accumulated from multiple batches, use the ``compute`` method:
+
+            >>> spro.compute()
+            tensor(0.5433)
+        """
+        targets = dim_zero_cat(self.targets)
+        preds = dim_zero_cat(self.preds)
+        return spro_score(preds, targets, threshold=self.threshold, saturation_config=self.saturation_config)
+
+def spro_score(predictions: torch.Tensor, targets: torch.Tensor,
+                threshold: float = 0.5, saturation_config: dict = {}) -> torch.Tensor:
+    """Calculate the sPRO score for a batch of predictions.
+
+    Args:
+        predictions (torch.Tensor): Predicted anomaly masks
+        targets: (torch.Tensor): Ground truth anomaly masks with non-binary values and, original height and width
+        threshold (float): When predictions are passed as float, the threshold is used to binarize the predictions.
+        saturation_config (dict): Saturations configuration for each label (pixel value) as the keys
+
+    Returns:
+        torch.Tensor: Scalar value representing the average sPRO score for the input batch.
+    """
+    predictions = torch.nn.functional.interpolate(predictions.unsqueeze(1), targets.shape[1:])
+
+    # Apply threshold to binary predictions
+    if predictions.dtype == torch.float:
+        predictions = predictions > threshold
+
+    score = torch.tensor(0.0)
+
+    # Iterate for each image in the batch
+    for i, target in enumerate(targets):
+        unique_labels = torch.unique(target)
+
+        # Iterate for each ground-truth mask per image
+        for label in unique_labels[1:]:
+            # Calculate true positive
+            target_per_label = target == label
+            true_pos = torch.sum(predictions[i] & target_per_label)
+
+            # Calculate the areas of the ground-truth
+            defect_areas = torch.sum(target_per_label)
+
+            if len(saturation_config) > 0:
+                # Adjust saturation threshold based on configuration
+                saturation_per_label = saturation_config[label.int().item()]
+                saturation_threshold = torch.minimum(saturation_per_label["saturation_threshold"], defect_areas)
+                if saturation_per_label["relative_saturation"]:
+                    saturation_threshold *= defect_areas
+            else:
+                # Handle case when saturation_config is empty
+                logger.warning("The saturation_config attribute is empty, the threshold is set to the defect areas."
+                               "This is equivalent to PRO metric but with the 'region' are separated by mask files")
+                saturation_threshold = defect_areas
+
+            # Update score with minimum of true_pos/saturation_threshold and 1.0
+            score += torch.minimum(true_pos / saturation_threshold, torch.tensor(1.0))
+
+    # Calculate the mean score
+    return torch.mean(score)

--- a/src/anomalib/metrics/spro.py
+++ b/src/anomalib/metrics/spro.py
@@ -109,7 +109,7 @@ def spro_score(predictions: torch.Tensor, targets: torch.Tensor,
         predictions = predictions > threshold
 
     score = torch.tensor(0.0)
-
+    m = 0
     # Iterate for each image in the batch
     for i, target in enumerate(targets):
         unique_labels = torch.unique(target)
@@ -137,6 +137,9 @@ def spro_score(predictions: torch.Tensor, targets: torch.Tensor,
 
             # Update score with minimum of true_pos/saturation_threshold and 1.0
             score += torch.minimum(true_pos / saturation_threshold, torch.tensor(1.0))
+            m += 1
 
-    # Calculate the mean score
-    return torch.mean(score)
+    # If there are only backgrounds
+    if m == 0:
+        return torch.tensor(1.0)
+    return score / m

--- a/src/configs/README.md
+++ b/src/configs/README.md
@@ -15,6 +15,7 @@ configs/
 │   ├── kolektor.yaml
 │   ├── mvtec_3d.yaml
 │   ├── mvtec.yaml
+│   ├── mvtec_loco.yaml
 │   ├── shanghaitec.yaml
 │   ├── ucsd_ped.yaml
 │   └── visa.yaml

--- a/src/configs/data/mvtec_loco.yaml
+++ b/src/configs/data/mvtec_loco.yaml
@@ -1,0 +1,18 @@
+class_path: anomalib.data.MVTecLoco
+init_args:
+  root: ./datasets/MVTec_LOCO
+  category: breakfast_box
+  image_size: [256, 256]
+  center_crop: null
+  normalization: imagenet
+  train_batch_size: 32
+  eval_batch_size: 32
+  num_workers: 8
+  task: SEGMENTATION
+  transform_config_train: null
+  transform_config_eval: null
+  test_split_mode: FROM_DIR
+  test_split_ratio: 0.2
+  val_split_mode: FROM_DIR
+  val_split_ratio: 0.5
+  seed: null

--- a/tests/unit/data/image/test_mvtec_loco.py
+++ b/tests/unit/data/image/test_mvtec_loco.py
@@ -1,0 +1,32 @@
+"""Unit Tests - MVTecLoco Datamodule."""
+
+# Copyright (C) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pytest
+
+from anomalib import TaskType
+from anomalib.data import MVTecLoco
+from tests.unit.data.base.image import _TestAnomalibImageDatamodule
+
+
+class TestMVTecLoco(_TestAnomalibImageDatamodule):
+    """MVTecLoco Datamodule Unit Tests."""
+
+    @pytest.fixture()
+    def datamodule(self, dataset_path: Path, task_type: TaskType) -> MVTecLoco:
+        """Create and return a MVTecLoco datamodule."""
+        _datamodule = MVTecLoco(
+            root=dataset_path / "mvtec_loco",
+            category="dummy",
+            task=task_type,
+            image_size=256,
+            train_batch_size=4,
+            eval_batch_size=4,
+        )
+        _datamodule.prepare_data()
+        _datamodule.setup()
+
+        return _datamodule


### PR DESCRIPTION
## 📝 Description

Add the implementation of MVTec LOCO AD dataset [[Paper](https://link.springer.com/article/10.1007/s11263-022-01578-9#Fn1)]

The dataset structure could contains multiple ground-truth masks for the corresponding anomalous images. The dataset `_setup` method will merge the multiple masks and store the merged ground-truth masks into a separate ground-truth directory via the `_merge_gt_mask` function.

Note: I used the downloadable dataset link found from this closed PR: https://github.com/openvinotoolkit/anomalib/pull/553

This PR does not include the implementation of sPRO metrics, which seems the metric is designed to additionally evaluate MVTec LOCO dataset. I plan to implement the metric in a separate PR later.

🛠️ Fixes #574 #471 #1341 

## ✨ Changes

Select what type of change your PR is:

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [x] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [x] 📚 I have made the necessary updates to the documentation (if applicable).
- [x] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
