### PR TITLE
🐞 Fix GMM test

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,6 +12,7 @@ pandas>=1.1.0
 lightning
 setuptools>=41.0.0
 timm>=0.5.4,<=0.6.13
+torch>=2,<2.2.0 # rkde export fails even with ONNX 17 (latest) with torch 2.2.0. TODO(ashwinvaidya17): revisit
 torchmetrics==0.10.3
 rich-argparse
 open-clip-torch>=2.23.0

--- a/tests/unit/models/components/clustering/test_gmm.py
+++ b/tests/unit/models/components/clustering/test_gmm.py
@@ -16,8 +16,8 @@ def test_fit_and_predict() -> None:
     # Create some synthetic data
     data = torch.cat(
         [
-            torch.randn(100, 2) + torch.tensor([2.0, 2.0]),
-            torch.randn(100, 2) + torch.tensor([-2.0, -2.0]),
+            torch.randn(100, 2) + torch.tensor([10.0, 10.0]),
+            torch.randn(100, 2) + torch.tensor([-10.0, -10.0]),
         ],
     )
 


### PR DESCRIPTION
## 📝 Description

- The `test_gmm.py` is flaky as the randomly generated datapoints might end up near the wrong cluster.
In the first image, the colours show the labels expected by the test but from the figure you can see that the clusters are close to the wrong cluster.

<img width="685" alt="image" src="https://github.com/openvinotoolkit/anomalib/assets/17232914/210918f6-5630-433a-b92a-5cdf4153e8d8">

The solution is probably too conservative but the new clusters are now separated by a large margin.


<img width="685" alt="image" src="https://github.com/openvinotoolkit/anomalib/assets/17232914/1f998eb5-5fe1-4d15-809e-e95099018ef4">


Select what type of change your PR is:

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
