### PR TITLE
🐞 Fix issues when validation and test split modes set to none

### DIFF
--- a/src/anomalib/engine/engine.py
+++ b/src/anomalib/engine/engine.py
@@ -23,6 +23,7 @@ from anomalib.callbacks.post_processor import _PostProcessorCallback
 from anomalib.callbacks.thresholding import _ThresholdCallback
 from anomalib.callbacks.visualizer import _VisualizationCallback
 from anomalib.data import AnomalibDataModule, AnomalibDataset, PredictDataset
+from anomalib.data.utils import TestSplitMode
 from anomalib.deploy.export import ExportType, export_to_onnx, export_to_openvino, export_to_torch
 from anomalib.metrics.threshold import BaseThreshold
 from anomalib.models import AnomalyModule
@@ -636,7 +637,7 @@ class Engine:
         test_dataloaders: EVAL_DATALOADERS | None = None,
         datamodule: AnomalibDataModule | None = None,
         ckpt_path: str | None = None,
-    ) -> _EVALUATE_OUTPUT:
+    ) -> _EVALUATE_OUTPUT | None:
         """Fits the model and then calls test on it.
 
         Args:
@@ -652,6 +653,9 @@ class Engine:
                 Defaults to None.
             ckpt_path (str | None, optional): Checkpoint path. If provided, the model will be loaded from this path.
                 Defaults to None.
+
+        Returns:
+            _EVALUATE_OUTPUT | None: A List of dictionaries containing the test results. 1 dict per dataloader.
 
         CLI Usage:
             1. you can pick a model, and you can run through the MVTec dataset.
@@ -674,7 +678,12 @@ class Engine:
             self.trainer.validate(model, val_dataloaders, None, verbose=False, datamodule=datamodule)
         else:
             self.trainer.fit(model, train_dataloaders, val_dataloaders, datamodule, ckpt_path)
-        self.trainer.test(model, test_dataloaders, ckpt_path=ckpt_path, datamodule=datamodule)
+
+        if datamodule is not None and datamodule.test_split_mode == TestSplitMode.NONE:
+            logger.info(f"The test_split_mode is set to '{TestSplitMode.NONE}'. Skipping test stage.")
+            logger.warning(f"Found {len(datamodule.test_data)} images in the test set.")
+            return None
+        return self.trainer.test(model, test_dataloaders, ckpt_path=ckpt_path, datamodule=datamodule)
 
     def export(
         self,


### PR DESCRIPTION
## 📝 Description

This PR is based on the close PR #1628:
- when val_split_mode is 'NONE' , skip the validation stage by setting `config.trainer.limit_val_batches` to 0.0
- when test_split_mode is 'NONE',  skip the test stage by including a conditional check `datamodule.test_split_mode == TestSplitMode.NONE`. To address a comment in the closed PR, a warning is provided to check the length of the test set that is being skipped.

- 🛠️ Fixes #1629 

## ✨ Changes

Select what type of change your PR is:

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
