### PR TITLE
Made input size optional when exporting

### DIFF
--- a/requirements/openvino.txt
+++ b/requirements/openvino.txt
@@ -1,3 +1,3 @@
-openvino-dev>=2023.0
-nncf>=2.5.0
+openvino-dev>=2023.1
+nncf>=2.6.0
 onnx>=1.13.1

--- a/src/anomalib/engine/engine.py
+++ b/src/anomalib/engine/engine.py
@@ -758,7 +758,6 @@ class Engine:
                 task=self.task,
             )
         elif export_type == ExportType.ONNX:
-            assert input_size is not None, "input_size must be provided for ONNX export."
             exported_model_path = export_to_onnx(
                 model=model,
                 input_size=input_size,
@@ -767,7 +766,6 @@ class Engine:
                 task=self.task,
             )
         elif export_type == ExportType.OPENVINO:
-            assert input_size is not None, "input_size must be provided for OpenVINO export."
             exported_model_path = export_to_openvino(
                 model=model,
                 input_size=input_size,

--- a/src/anomalib/models/components/feature_extractors/timm.py
+++ b/src/anomalib/models/components/feature_extractors/timm.py
@@ -74,6 +74,7 @@ class TimmFeatureExtractor(nn.Module):
             exportable=True,
             out_indices=self.idx,
         )
+        self.input_size = self.feature_extractor.default_cfg["input_size"][1:]
         self.out_dims = self.feature_extractor.feature_info.channels()
         self._features = {layer: torch.empty(0) for layer in self.layers}
 

--- a/src/anomalib/models/image/cflow/torch_model.py
+++ b/src/anomalib/models/image/cflow/torch_model.py
@@ -59,6 +59,7 @@ class CflowModel(nn.Module):
         self.condition_vector: int = condition_vector
         self.dec_arch = decoder
         self.pool_layers = layers
+        self.input_size = input_size
 
         self.encoder = TimmFeatureExtractor(backbone=self.backbone, layers=self.pool_layers, pre_trained=pre_trained)
         self.pool_dims = self.encoder.out_dims

--- a/src/anomalib/models/image/csflow/torch_model.py
+++ b/src/anomalib/models/image/csflow/torch_model.py
@@ -559,17 +559,20 @@ class CsFlowModel(nn.Module):
         num_channels: int = 3,
     ) -> None:
         super().__init__()
-        self.input_dims = (num_channels, *input_size)
+        self.input_size = input_size
         self.clamp = clamp
         self.cross_conv_hidden_channels = cross_conv_hidden_channels
         self.feature_extractor = MultiScaleFeatureExtractor(n_scales=3, input_size=input_size)
         self.graph = CrossScaleFlow(
-            input_dims=self.input_dims,
+            input_dims=(num_channels, *input_size),
             n_coupling_blocks=n_coupling_blocks,
             clamp=clamp,
             cross_conv_hidden_channels=cross_conv_hidden_channels,
         )
-        self.anomaly_map_generator = AnomalyMapGenerator(input_dims=self.input_dims, mode=AnomalyMapMode.ALL)
+        self.anomaly_map_generator = AnomalyMapGenerator(
+            input_dims=(num_channels, *input_size),
+            mode=AnomalyMapMode.ALL,
+        )
 
     def forward(self, images: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         """Forward method of the model.

--- a/src/anomalib/models/image/dfkde/torch_model.py
+++ b/src/anomalib/models/image/dfkde/torch_model.py
@@ -45,7 +45,7 @@ class DfkdeModel(nn.Module):
         super().__init__()
 
         self.feature_extractor = TimmFeatureExtractor(backbone=backbone, pre_trained=pre_trained, layers=layers).eval()
-
+        self.input_size = self.feature_extractor.input_size
         self.classifier = KDEClassifier(
             n_pca_components=n_pca_components,
             feature_scaling_method=feature_scaling_method,

--- a/src/anomalib/models/image/ganomaly/torch_model.py
+++ b/src/anomalib/models/image/ganomaly/torch_model.py
@@ -333,6 +333,7 @@ class GanomalyModel(nn.Module):
             n_features=n_features,
             extra_layers=extra_layers,
         )
+        self.input_size = input_size
         self.weights_init(self.generator)
         self.weights_init(self.discriminator)
 

--- a/src/anomalib/models/image/padim/torch_model.py
+++ b/src/anomalib/models/image/padim/torch_model.py
@@ -76,7 +76,7 @@ class PadimModel(nn.Module):
     ) -> None:
         super().__init__()
         self.tiler: Tiler | None = None
-
+        self.input_size = input_size
         self.backbone = backbone
         self.layers = layers
         self.feature_extractor = TimmFeatureExtractor(backbone=self.backbone, layers=layers, pre_trained=pre_trained)

--- a/src/anomalib/models/image/reverse_distillation/torch_model.py
+++ b/src/anomalib/models/image/reverse_distillation/torch_model.py
@@ -46,6 +46,7 @@ class ReverseDistillationModel(nn.Module):
         self.tiler: Tiler | None = None
 
         encoder_backbone = backbone
+        self.input_size = input_size
         self.encoder = TimmFeatureExtractor(backbone=encoder_backbone, pre_trained=pre_trained, layers=layers)
         self.bottleneck = get_bottleneck_layer(backbone)
         self.decoder = get_decoder(backbone)

--- a/src/anomalib/models/image/stfpm/torch_model.py
+++ b/src/anomalib/models/image/stfpm/torch_model.py
@@ -37,6 +37,7 @@ class STFPMModel(nn.Module):
         super().__init__()
         self.tiler: Tiler | None = None
 
+        self.input_size = input_size
         self.backbone = backbone
         self.teacher_model = TimmFeatureExtractor(backbone=self.backbone, pre_trained=True, layers=layers)
         self.student_model = TimmFeatureExtractor(

--- a/src/anomalib/pipelines/benchmarking/benchmark.py
+++ b/src/anomalib/pipelines/benchmarking/benchmark.py
@@ -139,8 +139,8 @@ def get_single_model_metrics(
             else:
                 input_size = model_config.data.init_args.image_size
             export_to_openvino(
-                export_root=Path(project_path),
                 model=model,
+                export_root=Path(project_path),
                 input_size=input_size,
                 transform=engine.trainer.datamodule.test_data.transform,
                 ov_args={},

--- a/tests/integration/model/test_models.py
+++ b/tests/integration/model/test_models.py
@@ -154,6 +154,7 @@ class TestAPI:
             dataset_path=dataset_path,
             project_path=project_path,
         )
+        engine.fit(model=model, datamodule=dataset)
         engine.export(
             model=model,
             datamodule=dataset,

--- a/tests/integration/tools/test_gradio_entrypoint.py
+++ b/tests/integration/tools/test_gradio_entrypoint.py
@@ -74,8 +74,8 @@ class TestGradioInferenceEntrypoint:
 
         # export OpenVINO model
         export_to_openvino(
-            export_root=_ckpt_path.parent.parent,
             model=model,
+            export_root=_ckpt_path.parent.parent,
             input_size=(256, 256),
             transform=transforms_config,
             ov_args={},

--- a/tests/integration/tools/test_openvino_entrypoint.py
+++ b/tests/integration/tools/test_openvino_entrypoint.py
@@ -45,8 +45,8 @@ class TestOpenVINOInferenceEntrypoint:
 
         # export OpenVINO model
         export_to_openvino(
-            export_root=_ckpt_path.parent.parent,
             model=model,
+            export_root=_ckpt_path.parent.parent,
             input_size=(256, 256),
             transform=transforms_config,
             ov_args={},


### PR DESCRIPTION
## 📝 Description

- Updated OpenVINO and NNCF to use save_model function
- Use compress_to_fp16 argument in conversion
- input_size is optional now for exporting

## ✨ Changes

Select what type of change your PR is:

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔨 Refactor (non-breaking change which refactors the code base)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [x] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](../docs/source/markdown/guides/developer/code_review_checklist.md).
