### PR TITLE
Update setup logic in model and datamodule

### DIFF
--- a/src/anomalib/data/base/datamodule.py
+++ b/src/anomalib/data/base/datamodule.py
@@ -120,7 +120,8 @@ class AnomalibDataModule(LightningDataModule, ABC):
             stage: str | None:  Train/Val/Test stages.
                 Defaults to ``None``.
         """
-        if not any(hasattr(self, subset) for subset in ["train_data", "val_data", "test_data"]) or not self._is_setup:
+        has_subset = any(hasattr(self, subset) for subset in ["train_data", "val_data", "test_data"])
+        if not has_subset or not self._is_setup:
             self._setup(stage)
             self._create_test_split()
             self._create_val_split()

--- a/src/anomalib/data/base/datamodule.py
+++ b/src/anomalib/data/base/datamodule.py
@@ -9,6 +9,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
 from lightning.pytorch import LightningDataModule
+from lightning.pytorch.trainer.states import TrainerFn
 from lightning.pytorch.utilities.types import EVAL_DATALOADERS, TRAIN_DATALOADERS
 from torch.utils.data.dataloader import DataLoader, default_collate
 from torchvision.transforms.v2 import Resize, Transform
@@ -110,6 +111,8 @@ class AnomalibDataModule(LightningDataModule, ABC):
 
         self._samples: DataFrame | None = None
 
+        self._is_setup = False  # flag to track if setup has been called from the trainer
+
     def setup(self, stage: str | None = None) -> None:
         """Set up train, validation and test data.
 
@@ -117,11 +120,13 @@ class AnomalibDataModule(LightningDataModule, ABC):
             stage: str | None:  Train/Val/Test stages.
                 Defaults to ``None``.
         """
-        if not self.is_setup:
+        if not any(hasattr(self, subset) for subset in ["train_data", "val_data", "test_data"]) or not self._is_setup:
             self._setup(stage)
             self._create_test_split()
             self._create_val_split()
-        assert self.is_setup
+            if isinstance(stage, TrainerFn):
+                # only set the flag if the stage is a TrainerFn, which means the setup has been called from a trainer
+                self._is_setup = True
 
     @abstractmethod
     def _setup(self, _stage: str | None = None) -> None:
@@ -181,19 +186,6 @@ class AnomalibDataModule(LightningDataModule, ABC):
         elif self.val_split_mode != ValSplitMode.NONE:
             msg = f"Unknown validation split mode: {self.val_split_mode}"
             raise ValueError(msg)
-
-    @property
-    def is_setup(self) -> bool:
-        """Checks if setup() has been called.
-
-        At least one of [train_data, val_data, test_data] should be setup.
-        """
-        _is_setup: bool = False
-        for data in ("train_data", "val_data", "test_data"):
-            if hasattr(self, data):
-                _is_setup = True
-
-        return _is_setup
 
     def train_dataloader(self) -> TRAIN_DATALOADERS:
         """Get train dataloader."""

--- a/src/anomalib/data/base/video.py
+++ b/src/anomalib/data/base/video.py
@@ -175,17 +175,8 @@ class AnomalibVideoDataset(AnomalibDataset, ABC):
 class AnomalibVideoDataModule(AnomalibDataModule):
     """Base class for video data modules."""
 
-    def setup(self, stage: str | None = None) -> None:
-        """Set up train, validation and test data.
-
-        Args:
-            stage: str | None:  Train/Val/Test stages.
-                Defaults to ``None``.
-        """
-        if not self.is_setup:
-            self._setup(stage)
-            self._create_val_split()
-        assert self.is_setup
+    def _create_test_split(self) -> None:
+        """Video datamodules do not support dynamic assignment of the test split."""
 
     def _setup(self, _stage: str | None = None) -> None:
         """Set up the datasets and perform dynamic subset splitting.

--- a/src/anomalib/models/image/winclip/lightning_model.py
+++ b/src/anomalib/models/image/winclip/lightning_model.py
@@ -55,7 +55,7 @@ class WinClip(AnomalyModule):
         self.k_shot = k_shot
         self.few_shot_source = Path(few_shot_source) if few_shot_source else None
 
-    def setup(self, stage: str) -> None:
+    def _setup(self) -> None:
         """Setup WinCLIP.
 
         - Set the class name used in the prompt ensemble.
@@ -63,11 +63,7 @@ class WinClip(AnomalyModule):
         - Collect reference images for few-shot inference.
 
         We need to pass the device because this hook is called before the model is moved to the device.
-
-        Args:
-            stage (str): The stage in which the setup is called. Usually ``"fit"``, ``"test"`` or ``predict``.
         """
-        del stage
         # get class name
         self.class_name = self._get_class_name()
         ref_images = None


### PR DESCRIPTION
## 📝 Description

Minor change in how we check if `self._setup` should be called in `setup`. The change is repeated in both the datamodule and the anomaly module. This is mainly to ensure that we can use the modules in a standalone fashion, without/before being attached to a trainer. For example, we could use the following to quickly inspect the images in our datamodule.
```python
>>> from anomalib.data import MVTec
>>>
>>> datamodule = MVTec(image_size=(512, 512))
>>> datamodule.setup()
>>>
>>> sample = next(iter(datamodule.train_dataloader()))
>>> sample["image"].shape
torch.Size([32, 3, 512, 512])
```
Similarly, we could inspect the structure of the torch model of a given Lightning model after invoking `setup`:
```python
>>> from anomalib.models import Ganomaly
>>>
>>> model = Ganomaly()
>>> model.setup()
>>>
>>> model.model.generator.encoder1.input_layers
Sequential(
  (initial-conv-3-64): Conv2d(3, 64, kernel_size=(4, 4), stride=(2, 2), padding=(4, 4), bias=False)
  (initial-relu-64): LeakyReLU(negative_slope=0.2, inplace=True)
)
```

Without the current change, this would lead to problems downstream when the entrypoints of the engine are called.

## ✨ Changes

Select what type of change your PR is:

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](../docs/source/markdown/guides/developer/code_review_checklist.md).
