### PR TITLE
🛠️ Ensure images are loaded in RGB format

### DIFF
--- a/src/anomalib/data/utils/image.py
+++ b/src/anomalib/data/utils/image.py
@@ -351,7 +351,7 @@ def read_image(path: str | Path, as_tensor: bool = False) -> torch.Tensor | np.n
     Returns:
         image as numpy array
     """
-    image = Image.open(path)
+    image = Image.open(path).convert("RGB")
     return to_dtype(to_image(image), torch.float32, scale=True) if as_tensor else np.array(image) / 255.0
 
 
@@ -441,7 +441,7 @@ def save_image(filename: Path | str, image: np.ndarray | Figure, root: Path | No
     # if file_path is absolute, then root is ignored
     # so we remove the top level directory from the path
     if file_path.is_absolute() and root:
-        file_path = Path("/".join(str(file_path).split("/")[2:]))
+        file_path = Path(*file_path.parts[2:])  # OS-AGNOSTIC
     if root:
         file_path = root / file_path
 


### PR DESCRIPTION
## 📝 Description

Currently, loading grayscale images leads to errors in the visualization callback, because the channels are missing.
This change ensure that images are always loaded as RGB.

Additionally fixes:
- 🛠️ #1831

## ✨ Changes

Select what type of change your PR is:

- [ x ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](../docs/source/markdown/guides/developer/code_review_checklist.md).
