### PR TITLE
Changed prediction label assignment for OpenVINO inferencer

### DIFF
--- a/src/anomalib/deploy/inferencers/openvino_inferencer.py
+++ b/src/anomalib/deploy/inferencers/openvino_inferencer.py
@@ -247,8 +247,10 @@ class OpenVINOInferencer(Inferencer):
         # Common practice in anomaly detection is to assign anomalous
         # label to the prediction if the prediction score is greater
         # than the image threshold.
+        pred_label: str | None = None
         if "image_threshold" in metadata:
-            pred_label = pred_score >= metadata["image_threshold"]
+            pred_idx = pred_score >= metadata["image_threshold"]
+            pred_label = "Anomalous" if pred_idx else "Normal"
 
         if task == TaskType.CLASSIFICATION:
             _, pred_score = self._normalize(pred_scores=pred_score, metadata=metadata)


### PR DESCRIPTION
Fixed incorrect label assignment.
Was True/False, now it's "Anomalous/Normal" as for the PyTorch inferencer in torch_inferencer.py

## 📝 Description

- Provide a clear summary of the changes and the issue that has been addressed.
- 🛠️ Fixes # (issue number)

## ✨ Changes

Select what type of change your PR is:

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](../docs/source/markdown/guides/developer/code_review_checklist.md).
