### PR TITLE
Address minor WinCLIP issues

### DIFF
--- a/src/anomalib/models/image/winclip/README.md
+++ b/src/anomalib/models/image/winclip/README.md
@@ -22,13 +22,11 @@ WinCLIP is a zero-shot model, which means that we can directly evaluate the mode
 
 ### 0-Shot
 
-`anomalib test --model WinClip --data MVTec --data.image_size 240 --data.normalization clip`
+`anomalib test --model WinClip --data MVTec`
 
 ### 1-Shot
 
-`anomalib test --model WinClip --model.k_shot  1 --data MVTec --data.image_size 240 --data.normalization clip`
-
-> **Note:** The `data.image_size` and `data.normalization` parameters must be set to the above values to match the configuration in which the pre-trained CLIP model weights were obtained.
+`anomalib test --model WinClip --model.k_shot  1 --data MVTec`
 
 ## Parameters
 

--- a/src/anomalib/models/image/winclip/lightning_model.py
+++ b/src/anomalib/models/image/winclip/lightning_model.py
@@ -13,7 +13,7 @@ from typing import Any
 
 import torch
 from torch.utils.data import DataLoader
-from torchvision.transforms.v2 import Compose, Normalize, Resize, Transform
+from torchvision.transforms.v2 import Compose, InterpolationMode, Normalize, Resize, Transform
 
 from anomalib import LearningType
 from anomalib.data.predict import PredictDataset
@@ -174,7 +174,7 @@ class WinClip(AnomalyModule):
             logger.warning("Image size is not used in WinCLIP. The input image size is determined by the model.")
         return Compose(
             [
-                Resize((240, 240), antialias=True),
+                Resize((240, 240), antialias=True, interpolation=InterpolationMode.BICUBIC),
                 Normalize(mean=(0.48145466, 0.4578275, 0.40821073), std=(0.26862954, 0.26130258, 0.27577711)),
             ],
         )


### PR DESCRIPTION
## 📝 Description

Quick PR that addresses some minor issues with the WinCLIP transforms and readme.

- use bicubic interpolation in resize, needed to be in line with backbone pre-training transforms
- Update the instructions for running the model in the readme (passing image size and normalization stats no longer needed since v1).

## ✨ Changes

Select what type of change your PR is:

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](../docs/source/markdown/guides/developer/code_review_checklist.md).
