### PR TITLE
Fix video bug and add tests

### DIFF
--- a/src/anomalib/data/base/video.py
+++ b/src/anomalib/data/base/video.py
@@ -167,6 +167,9 @@ class AnomalibVideoDataset(AnomalibDataset, ABC):
         elif self.transform:
             item["image"] = self.transform(item["image"])
 
+        # squeeze temporal dimensions in case clip length is 1
+        item["image"] = item["image"].squeeze(0)
+
         # include only target frame in gt
         if self.clip_length_in_frames > 1 and self.target_frame != VideoTargetFrame.ALL:
             item = self._select_targets(item)

--- a/tests/unit/data/base/video.py
+++ b/tests/unit/data/base/video.py
@@ -59,3 +59,14 @@ class _TestAnomalibVideoDatamodule(_TestAnomalibDataModule):
         assert clip.dtype == torch.float32
         assert clip.min() >= 0
         assert clip.max() <= 1
+
+    @pytest.mark.parametrize("clip_length_in_frames", [1])
+    def test_single_frame_squeezed(self, datamodule: AnomalibDataModule) -> None:
+        """Test that the temporal dimension is squeezed when the clip lenght is 1."""
+        # Get the dataloader.
+        dataloader = datamodule.train_dataloader()
+
+        # Get the first batch.
+        batch = next(iter(dataloader))
+        clip = batch["image"]
+        assert clip.shape == (4, 3, 256, 256)

--- a/tests/unit/data/base/video.py
+++ b/tests/unit/data/base/video.py
@@ -3,8 +3,8 @@
 # Copyright (C) 2023-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-
 import pytest
+import torch
 
 from anomalib.data import AnomalibDataModule
 
@@ -46,3 +46,16 @@ class _TestAnomalibVideoDatamodule(_TestAnomalibDataModule):
             assert len(batch["label"]) == 4
             assert batch["mask"].shape == (4, 256, 256)
             assert batch["mask"].shape == (4, 256, 256)
+
+    @pytest.mark.parametrize("subset", ["train", "val", "test"])
+    def test_item_dtype(self, datamodule: AnomalibDataModule, subset: str) -> None:
+        """Test that the input tensor is of float type and scaled between 0-1."""
+        # Get the dataloader.
+        dataloader = getattr(datamodule, f"{subset}_dataloader")()
+
+        # Get the first batch.
+        batch = next(iter(dataloader))
+        clip = batch["image"]
+        assert clip.dtype == torch.float32
+        assert clip.min() >= 0
+        assert clip.max() <= 1

--- a/tests/unit/data/video/test_avenue.py
+++ b/tests/unit/data/video/test_avenue.py
@@ -16,11 +16,17 @@ class TestAvenue(_TestAnomalibVideoDatamodule):
     """Avenue Datamodule Unit Tests."""
 
     @pytest.fixture()
-    def datamodule(self, dataset_path: Path, task_type: TaskType) -> Avenue:
+    def clip_length_in_frames(self) -> int:
+        """Return the number of frames in each clip."""
+        return 2
+
+    @pytest.fixture()
+    def datamodule(self, dataset_path: Path, task_type: TaskType, clip_length_in_frames: int) -> Avenue:
         """Create and return a Avenue datamodule."""
         _datamodule = Avenue(
             root=dataset_path / "avenue",
             gt_dir=dataset_path / "avenue" / "ground_truth_demo",
+            clip_length_in_frames=clip_length_in_frames,
             image_size=256,
             task=task_type,
             num_workers=0,

--- a/tests/unit/data/video/test_shanghaitech.py
+++ b/tests/unit/data/video/test_shanghaitech.py
@@ -17,11 +17,17 @@ class TestShanghaiTech(_TestAnomalibVideoDatamodule):
     """ShanghaiTech Datamodule Unit Tests."""
 
     @pytest.fixture()
-    def datamodule(self, dataset_path: Path, task_type: TaskType) -> ShanghaiTech:
+    def clip_length_in_frames(self) -> int:
+        """Return the number of frames in each clip."""
+        return 2
+
+    @pytest.fixture()
+    def datamodule(self, dataset_path: Path, task_type: TaskType, clip_length_in_frames: int) -> ShanghaiTech:
         """Create and return a Shanghai datamodule."""
         _datamodule = ShanghaiTech(
             root=dataset_path / "shanghaitech",
             scene=1,
+            clip_length_in_frames=clip_length_in_frames,
             image_size=(256, 256),
             train_batch_size=4,
             eval_batch_size=4,

--- a/tests/unit/data/video/test_ucsdped.py
+++ b/tests/unit/data/video/test_ucsdped.py
@@ -16,11 +16,17 @@ class TestUCSDped(_TestAnomalibVideoDatamodule):
     """UCSDped Datamodule Unit Tests."""
 
     @pytest.fixture()
-    def datamodule(self, dataset_path: Path, task_type: TaskType) -> UCSDped:
+    def clip_length_in_frames(self) -> int:
+        """Return the number of frames in each clip."""
+        return 2
+
+    @pytest.fixture()
+    def datamodule(self, dataset_path: Path, task_type: TaskType, clip_length_in_frames: int) -> UCSDped:
         """Create and return a UCSDped datamodule."""
         _datamodule = UCSDped(
             root=dataset_path / "ucsdped",
             category="dummy",
+            clip_length_in_frames=clip_length_in_frames,
             task=task_type,
             image_size=256,
             train_batch_size=4,


### PR DESCRIPTION
## 📝 Description

- Minor bugfix: Squeeze temporal dimension in video inputs when clip length is 1. This is to ensure compatibility of single frame video with image models.
- Add test case for the above bug
- Add test case for https://github.com/openvinotoolkit/anomalib/pull/1902

## ✨ Changes

Select what type of change your PR is:

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
