### PR TITLE
Refactored-make_folder3d_dataset-ruff-error-C901

### DIFF
--- a/src/anomalib/data/depth/folder_3d.py
+++ b/src/anomalib/data/depth/folder_3d.py
@@ -25,7 +25,99 @@ from anomalib.data.utils import (
 from anomalib.data.utils.path import _prepare_files_labels, validate_and_resolve_path
 
 
-def make_folder3d_dataset(  # noqa: C901
+def make_path_dirs(
+    normal_dir: str | Path,
+    abnormal_dir: str | Path | None = None,
+    normal_test_dir: str | Path | None = None,
+    mask_dir: str | Path | None = None,
+    normal_depth_dir: str | Path | None = None,
+    abnormal_depth_dir: str | Path | None = None,
+    normal_test_depth_dir: str | Path | None = None,
+) -> dict:
+    """Create a dictionary containing paths to different directories."""
+    dirs = {DirType.NORMAL: normal_dir}
+
+    if abnormal_dir:
+        dirs[DirType.ABNORMAL] = abnormal_dir
+
+    if normal_test_dir:
+        dirs[DirType.NORMAL_TEST] = normal_test_dir
+
+    if normal_depth_dir:
+        dirs[DirType.NORMAL_DEPTH] = normal_depth_dir
+
+    if abnormal_depth_dir:
+        dirs[DirType.ABNORMAL_DEPTH] = abnormal_depth_dir
+
+    if normal_test_depth_dir:
+        dirs[DirType.NORMAL_TEST_DEPTH] = normal_test_depth_dir
+
+    if mask_dir:
+        dirs[DirType.MASK] = mask_dir
+    return dirs
+
+
+def add_mask(
+    samples: DataFrame,
+    normal_depth_dir: str | Path | None = None,
+    abnormal_dir: str | Path | None = None,
+    normal_test_dir: str | Path | None = None,
+    mask_dir: str | Path | None = None,
+) -> DataFrame:
+    """If a path to mask is provided, add it to the sample dataframe."""
+    if normal_depth_dir:
+        samples.loc[samples.label == DirType.NORMAL, "depth_path"] = samples.loc[
+            samples.label == DirType.NORMAL_DEPTH
+        ].image_path.to_numpy()
+        samples.loc[samples.label == DirType.ABNORMAL, "depth_path"] = samples.loc[
+            samples.label == DirType.ABNORMAL_DEPTH
+        ].image_path.to_numpy()
+
+        if normal_test_dir:
+            samples.loc[samples.label == DirType.NORMAL_TEST, "depth_path"] = samples.loc[
+                samples.label == DirType.NORMAL_TEST_DEPTH
+            ].image_path.to_numpy()
+
+        # make sure every rgb image has a corresponding depth image and that the file exists
+        mismatch = (
+            samples.loc[samples.label_index == LabelName.ABNORMAL]
+            .apply(lambda x: Path(x.image_path).stem in Path(x.depth_path).stem, axis=1)
+            .all()
+        )
+        if not mismatch:
+            msg = """Mismatch between anomalous images and depth images. Make sure the mask files
+            in 'xyz' folder follow the same naming convention as the anomalous images in the dataset
+            (e.g. image: '000.png', depth: '000.tiff')."""
+            raise MisMatchError(msg)
+
+        missing_depth_files = samples.depth_path.apply(
+            lambda x: Path(x).exists() if not isna(x) else True,
+        ).all()
+        if not missing_depth_files:
+            msg = "Missing depth image files."
+            raise FileNotFoundError(msg)
+
+        samples = samples.astype({"depth_path": "str"})
+
+    if mask_dir and abnormal_dir:
+        samples.loc[samples.label == DirType.ABNORMAL, "mask_path"] = samples.loc[
+            samples.label == DirType.MASK
+        ].image_path.to_numpy()
+        samples["mask_path"] = samples["mask_path"].fillna("")
+        samples = samples.astype({"mask_path": "str"})
+
+        # make sure all the files exist
+        if not samples.mask_path.apply(
+            lambda x: Path(x).exists() if x != "" else True,
+        ).all():
+            msg = f"Missing mask files. mask_dir={mask_dir}"
+            raise FileNotFoundError(msg)
+    else:
+        samples["mask_path"] = ""
+    return samples
+
+
+def make_folder3d_dataset(
     normal_dir: str | Path,
     root: str | Path | None = None,
     abnormal_dir: str | Path | None = None,
@@ -81,25 +173,15 @@ def make_folder3d_dataset(  # noqa: C901
 
     filenames = []
     labels = []
-    dirs = {DirType.NORMAL: normal_dir}
-
-    if abnormal_dir:
-        dirs[DirType.ABNORMAL] = abnormal_dir
-
-    if normal_test_dir:
-        dirs[DirType.NORMAL_TEST] = normal_test_dir
-
-    if normal_depth_dir:
-        dirs[DirType.NORMAL_DEPTH] = normal_depth_dir
-
-    if abnormal_depth_dir:
-        dirs[DirType.ABNORMAL_DEPTH] = abnormal_depth_dir
-
-    if normal_test_depth_dir:
-        dirs[DirType.NORMAL_TEST_DEPTH] = normal_test_depth_dir
-
-    if mask_dir:
-        dirs[DirType.MASK] = mask_dir
+    dirs = make_path_dirs(
+        normal_dir,
+        abnormal_dir,
+        normal_test_dir,
+        mask_dir,
+        normal_depth_dir,
+        abnormal_depth_dir,
+        normal_test_depth_dir,
+    )
 
     for dir_type, path in dirs.items():
         filename, label = _prepare_files_labels(path, dir_type, extensions)
@@ -118,56 +200,7 @@ def make_folder3d_dataset(  # noqa: C901
     samples.label_index = samples.label_index.astype("Int64")
 
     # If a path to mask is provided, add it to the sample dataframe.
-    if normal_depth_dir:
-        samples.loc[samples.label == DirType.NORMAL, "depth_path"] = samples.loc[
-            samples.label == DirType.NORMAL_DEPTH
-        ].image_path.to_numpy()
-        samples.loc[samples.label == DirType.ABNORMAL, "depth_path"] = samples.loc[
-            samples.label == DirType.ABNORMAL_DEPTH
-        ].image_path.to_numpy()
-
-        if normal_test_dir:
-            samples.loc[samples.label == DirType.NORMAL_TEST, "depth_path"] = samples.loc[
-                samples.label == DirType.NORMAL_TEST_DEPTH
-            ].image_path.to_numpy()
-
-        # make sure every rgb image has a corresponding depth image and that the file exists
-        mismatch = (
-            samples.loc[samples.label_index == LabelName.ABNORMAL]
-            .apply(lambda x: Path(x.image_path).stem in Path(x.depth_path).stem, axis=1)
-            .all()
-        )
-        if not mismatch:
-            msg = """Mismatch between anomalous images and depth images. Make sure the mask files
-            in 'xyz' folder follow the same naming convention as the anomalous images in the dataset
-            (e.g. image: '000.png', depth: '000.tiff')."""
-            raise MisMatchError(msg)
-
-        missing_depth_files = samples.depth_path.apply(
-            lambda x: Path(x).exists() if not isna(x) else True,
-        ).all()
-        if not missing_depth_files:
-            msg = "Missing depth image files."
-            raise FileNotFoundError(msg)
-
-        samples = samples.astype({"depth_path": "str"})
-
-    # If a path to mask is provided, add it to the sample dataframe.
-    if mask_dir and abnormal_dir:
-        samples.loc[samples.label == DirType.ABNORMAL, "mask_path"] = samples.loc[
-            samples.label == DirType.MASK
-        ].image_path.to_numpy()
-        samples["mask_path"] = samples["mask_path"].fillna("")
-        samples = samples.astype({"mask_path": "str"})
-
-        # make sure all the files exist
-        if not samples.mask_path.apply(
-            lambda x: Path(x).exists() if x != "" else True,
-        ).all():
-            msg = f"Missing mask files. mask_dir={mask_dir}"
-            raise FileNotFoundError(msg)
-    else:
-        samples["mask_path"] = ""
+    samples = add_mask(samples, normal_depth_dir, abnormal_dir, normal_test_dir, mask_dir)
 
     # remove all the rows with temporal image samples that have already been assigned
     samples = samples.loc[


### PR DESCRIPTION
- fixes: #1826 

Refactored `make_folder_3d_dataset` into three separate functions to improve readability and maintainability:

`make_folder_3d_dataset`: Handles the overall process of generating a 3D dataset by calling `make_path_dir` and `add_mask`.

Since the make_folder_3d_dataset function is only used once in the codebase, this refactoring should not significantly impact the overall structure while enhancing the clarity of the code and remove the ruff C901 error.






