### PR TITLE
🐞 Fix dimensionality mismatch issue caused by the new kornia version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ core = [
     "einops>=0.3.2",
     "freia>=0.2",
     "imgaug==0.4.0",
-    "kornia>=0.6.6,<0.6.10",
+    "kornia>=0.6.6",
     "matplotlib>=3.4.3",
     "opencv-python>=4.5.3.56",
     "pandas>=1.1.0",

--- a/src/anomalib/models/components/filters/blur.py
+++ b/src/anomalib/models/components/filters/blur.py
@@ -64,7 +64,16 @@ class GaussianBlur2d(nn.Module):
         self.register_buffer("kernel", get_gaussian_kernel2d(kernel_size=kernel_size, sigma=sigma))
         if normalize:
             self.kernel = normalize_kernel2d(self.kernel)
-        self.kernel.unsqueeze_(0).unsqueeze_(0)
+
+        # Check if the kernel is 2d or 3d and expand it to the number of channels.
+        if self.kernel.ndim == 2:  # For kornia versions < 0.7.0
+            self.kernel.unsqueeze_(0).unsqueeze_(0)
+        elif self.kernel.ndim == 3:  # For kornia versions >= 0.7.0
+            self.kernel.unsqueeze_(0)
+        else:
+            msg = "Kernel should be either 2d or 3d."
+            raise ValueError(msg)
+
         self.kernel = self.kernel.expand(self.channels, -1, -1, -1)
         self.border_type = border_type
         self.padding = padding

--- a/src/anomalib/models/components/filters/blur.py
+++ b/src/anomalib/models/components/filters/blur.py
@@ -65,14 +65,7 @@ class GaussianBlur2d(nn.Module):
         if normalize:
             self.kernel = normalize_kernel2d(self.kernel)
 
-        # Check if the kernel is 2d or 3d and expand it to the number of channels.
-        if self.kernel.ndim == 2:  # For kornia versions < 0.7.0
-            self.kernel.unsqueeze_(0).unsqueeze_(0)
-        elif self.kernel.ndim == 3:  # For kornia versions >= 0.7.0
-            self.kernel.unsqueeze_(0)
-        else:
-            msg = "Kernel should be either 2d or 3d."
-            raise ValueError(msg)
+        self.kernel = self.kernel.view(1, 1, *self.kernel.shape[-2:])
 
         self.kernel = self.kernel.expand(self.channels, -1, -1, -1)
         self.border_type = border_type


### PR DESCRIPTION
## 📝 Description

- `get_gaussian_kernel2d` function in kornia returns `1xMxN` kernel in the new version. In the previous versions of kornia, on the other hand, this was `MxN`. This difference causes a dimensionality mismatch issues.
- 🛠️ Fixes #1798 

## ✨ Changes

Select what type of change your PR is:

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
