### PR TITLE
Fix anomaly map shape to also work with tiling

### DIFF
--- a/src/anomalib/data/utils/tiler.py
+++ b/src/anomalib/data/utils/tiler.py
@@ -378,7 +378,7 @@ class Tiler:
         if self.input_h < self.tile_size_h or self.input_w < self.tile_size_w:
             msg = (
                 f"One of the edges of the tile size {self.tile_size_h, self.tile_size_w} is larger than "
-                f"that of the image {{self.input_h, self.input_w}}."
+                f"that of the image {self.input_h, self.input_w}."
             )
             raise ValueError(
                 msg,

--- a/src/anomalib/models/image/padim/torch_model.py
+++ b/src/anomalib/models/image/padim/torch_model.py
@@ -126,6 +126,7 @@ class PadimModel(nn.Module):
             torch.Size([32, 128, 28, 28]),
             torch.Size([32, 256, 14, 14])]
         """
+        output_size = input_tensor.shape[-2:]
         if self.tiler:
             input_tensor = self.tiler.tile(input_tensor)
 
@@ -143,7 +144,7 @@ class PadimModel(nn.Module):
                 embedding=embeddings,
                 mean=self.gaussian.mean,
                 inv_covariance=self.gaussian.inv_covariance,
-                image_size=input_tensor.shape[-2:],
+                image_size=output_size,
             )
         return output
 

--- a/src/anomalib/models/image/patchcore/torch_model.py
+++ b/src/anomalib/models/image/patchcore/torch_model.py
@@ -70,6 +70,7 @@ class PatchcoreModel(DynamicBufferMixin, nn.Module):
         Returns:
             Tensor | dict[str, torch.Tensor]: Embedding for training, anomaly map and anomaly score for testing.
         """
+        output_size = input_tensor.shape[-2:]
         if self.tiler:
             input_tensor = self.tiler.tile(input_tensor)
 
@@ -98,7 +99,7 @@ class PatchcoreModel(DynamicBufferMixin, nn.Module):
             # reshape to w, h
             patch_scores = patch_scores.reshape((batch_size, 1, width, height))
             # get anomaly map
-            anomaly_map = self.anomaly_map_generator(patch_scores, input_tensor.shape[-2:])
+            anomaly_map = self.anomaly_map_generator(patch_scores, output_size)
 
             output = {"anomaly_map": anomaly_map, "pred_score": pred_score}
 

--- a/src/anomalib/models/image/stfpm/torch_model.py
+++ b/src/anomalib/models/image/stfpm/torch_model.py
@@ -61,6 +61,7 @@ class STFPMModel(nn.Module):
         Returns:
           Teacher and student features when in training mode, otherwise the predicted anomaly maps.
         """
+        output_size = images.shape[-2:]
         if self.tiler:
             images = self.tiler.tile(images)
         teacher_features: dict[str, torch.Tensor] = self.teacher_model(images)
@@ -78,7 +79,7 @@ class STFPMModel(nn.Module):
             output = self.anomaly_map_generator(
                 teacher_features=teacher_features,
                 student_features=student_features,
-                image_size=images.shape[-2:],
+                image_size=output_size,
             )
 
         return output


### PR DESCRIPTION
## 📝 Description

Fixes the problem where shape of anomaly map isn't set correctly in case of tiling.
- 🛠️ Fixes #1958

## ✨ Changes

Select what type of change your PR is:

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
