### PR TITLE
🔨 Replace `@abstractproperty` since it is deprecated

### DIFF
--- a/src/anomalib/models/components/base/anomaly_module.py
+++ b/src/anomalib/models/components/base/anomaly_module.py
@@ -5,7 +5,7 @@
 
 import importlib
 import logging
-from abc import ABC, abstractproperty
+from abc import ABC, abstractmethod
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Any
 
@@ -136,20 +136,21 @@ class AnomalyModule(pl.LightningModule, ABC):
 
         return self.predict_step(batch, batch_idx)
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def trainer_arguments(self) -> dict[str, Any]:
         """Arguments used to override the trainer parameters so as to train the model correctly."""
         raise NotImplementedError
 
     def _save_to_state_dict(self, destination: OrderedDict, prefix: str, keep_vars: bool) -> None:
         if hasattr(self, "image_threshold"):
-            destination[
-                "image_threshold_class"
-            ] = f"{self.image_threshold.__class__.__module__}.{self.image_threshold.__class__.__name__}"
+            destination["image_threshold_class"] = (
+                f"{self.image_threshold.__class__.__module__}.{self.image_threshold.__class__.__name__}"
+            )
         if hasattr(self, "pixel_threshold"):
-            destination[
-                "pixel_threshold_class"
-            ] = f"{self.pixel_threshold.__class__.__module__}.{self.pixel_threshold.__class__.__name__}"
+            destination["pixel_threshold_class"] = (
+                f"{self.pixel_threshold.__class__.__module__}.{self.pixel_threshold.__class__.__name__}"
+            )
         if hasattr(self, "normalization_metrics"):
             normalization_class = self.normalization_metrics.__class__
             destination["normalization_class"] = f"{normalization_class.__module__}.{normalization_class.__name__}"
@@ -203,7 +204,8 @@ class AnomalyModule(pl.LightningModule, ABC):
         module = importlib.import_module(".".join(class_path.split(".")[:-1]))
         return getattr(module, class_path.split(".")[-1])()
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def learning_type(self) -> LearningType:
         """Learning type of the model."""
         raise NotImplementedError

--- a/src/anomalib/models/components/base/anomaly_module.py
+++ b/src/anomalib/models/components/base/anomaly_module.py
@@ -144,13 +144,13 @@ class AnomalyModule(pl.LightningModule, ABC):
 
     def _save_to_state_dict(self, destination: OrderedDict, prefix: str, keep_vars: bool) -> None:
         if hasattr(self, "image_threshold"):
-            destination["image_threshold_class"] = (
-                f"{self.image_threshold.__class__.__module__}.{self.image_threshold.__class__.__name__}"
-            )
+            destination[
+                "image_threshold_class"
+            ] = f"{self.image_threshold.__class__.__module__}.{self.image_threshold.__class__.__name__}"
         if hasattr(self, "pixel_threshold"):
-            destination["pixel_threshold_class"] = (
-                f"{self.pixel_threshold.__class__.__module__}.{self.pixel_threshold.__class__.__name__}"
-            )
+            destination[
+                "pixel_threshold_class"
+            ] = f"{self.pixel_threshold.__class__.__module__}.{self.pixel_threshold.__class__.__name__}"
         if hasattr(self, "normalization_metrics"):
             normalization_class = self.normalization_metrics.__class__
             destination["normalization_class"] = f"{normalization_class.__module__}.{normalization_class.__name__}"


### PR DESCRIPTION
## 📝 Description

- This PR replaces `@abstractproperty` with `@property` `@abstractmethod` as the former is now deprecated.

## ✨ Changes

Select what type of change your PR is:

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
