### PR TITLE
🐞 Fix EfficientAD's pretrained weigths load path

### DIFF
--- a/src/anomalib/models/image/efficient_ad/lightning_model.py
+++ b/src/anomalib/models/image/efficient_ad/lightning_model.py
@@ -125,7 +125,7 @@ class EfficientAd(AnomalyModule):
         if not (pretrained_models_dir / "efficientad_pretrained_weights").is_dir():
             download_and_extract(pretrained_models_dir, WEIGHTS_DOWNLOAD_INFO)
         teacher_path = (
-            pretrained_models_dir / "efficientad_pretrained_weights" / f"pretrained_teacher_{self.model_size}.pth"
+            pretrained_models_dir / "efficientad_pretrained_weights" / f"pretrained_teacher_{self.model_size.value}.pth"
         )
         logger.info(f"Load pretrained teacher model from {teacher_path}")
         self.model.teacher.load_state_dict(torch.load(teacher_path, map_location=torch.device(self.device)))


### PR DESCRIPTION
## 📝 Description

- Downloaded and extracted EfficientAD's pretrained models' filenames are "pretrained_teacher_**small**.pth" or "pretrained_teacher_**medium**.pth"
- But, loaded pretrained models' filenames are "pretrained_teacher_**EfficientAdModelSize.S**.pth" or "pretrained_teacher_**EfficientAdModelSize.M**.pth", because of getting load path with string interpolation with model size enum itself.
- Fix load path interpolation to use associated enum value("small" or "medium")
- 🛠️ Fixes #1965 

## ✨ Changes

Select what type of change your PR is:

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [x] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [x] 📚 I have made the necessary updates to the documentation (if applicable).
- [x] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
