### PR TITLE
Fix test-val dsize.empty in video anomalib

### DIFF
--- a/src/anomalib/utils/visualization/image.py
+++ b/src/anomalib/utils/visualization/image.py
@@ -145,6 +145,7 @@ class ImageVisualizer(BaseVisualizer):
             elif "video_path" in batch:
                 height, width = batch["image"].shape[-2:]
                 image = batch["original_image"][i].squeeze().cpu().numpy()
+                image = image.transpose(1, 2, 0)
                 image = cv2.resize(image, dsize=(width, height), interpolation=cv2.INTER_AREA)
             else:
                 msg = "Batch must have either 'image_path' or 'video_path' defined."


### PR DESCRIPTION
Signed-off-by: Bepitic <bepitic@gmail.com>

## 📝 Description

The error of size being empty in the function of resize, can be because of:
- 1th, it is empty, (not our case)
- 2th the third dimension(channels) in the image is more than 512(our case).
 In our case we are providing the image in the shape of [C, X, Y] and cv2 resize expects, [ X, Y, C].
 This PR only arranges de dimensionality to match the shape

- 🛠️ Fixes  #1969

## ✨ Changes

Select what type of change your PR is:

- [X] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
