### PR TITLE
Fixed keys in data configs to fit AnomalibDataModule parameters

### DIFF
--- a/configs/data/avenue.yaml
+++ b/configs/data/avenue.yaml
@@ -6,13 +6,12 @@ init_args:
   frames_between_clips: 1
   target_frame: last
   image_size: [256, 256]
-  center_crop: null
-  normalization: imagenet
+  transform: null
   train_batch_size: 32
   eval_batch_size: 32
   num_workers: 8
-  transform_config_train: null
-  transform_config_eval: null
+  train_transform: null
+  eval_transform: null
   val_split_mode: from_test
   val_split_ratio: 0.5
   seed: null

--- a/configs/data/btech.yaml
+++ b/configs/data/btech.yaml
@@ -3,13 +3,12 @@ init_args:
   root: "./dtasets/BTech"
   category: "01"
   image_size: [256, 256]
-  center_crop: null
-  normalization: imagenet
+  transform: null
   train_batch_size: 32
   eval_batch_size: 32
   num_workers: 8
-  transform_config_train: null
-  transform_config_eval: null
+  train_transform: null
+  eval_transform: null
   test_split_mode: from_dir
   test_split_ratio: 0.2
   val_split_mode: same_as_test

--- a/configs/data/folder.yaml
+++ b/configs/data/folder.yaml
@@ -9,14 +9,13 @@ init_args:
   normal_split_ratio: 0
   extensions: [".png"]
   image_size: [256, 256]
-  center_crop: null
-  normalization: imagenet
+  transform: null
   train_batch_size: 32
   eval_batch_size: 32
   num_workers: 8
   task: segmentation
-  transform_config_train: null
-  transform_config_eval: null
+  train_transform: null
+  eval_transform: null
   test_split_mode: from_dir
   test_split_ratio: 0.2
   val_split_mode: same_as_test

--- a/configs/data/kolektor.yaml
+++ b/configs/data/kolektor.yaml
@@ -2,13 +2,12 @@ class_path: anomalib.data.Kolektor
 init_args:
   root: "./datasets/kolektor"
   image_size: [256, 256]
-  center_crop: null
-  normalization: imagenet
+  transform: null
   train_batch_size: 32
   eval_batch_size: 32
   num_workers: 8
-  transform_config_train: null
-  transform_config_eval: null
+  train_transform: null
+  eval_transform: null
   test_split_mode: from_dir
   test_split_ratio: 0.2
   val_split_mode: same_as_test

--- a/configs/data/mvtec.yaml
+++ b/configs/data/mvtec.yaml
@@ -3,14 +3,13 @@ init_args:
   root: ./datasets/MVTec
   category: bottle
   image_size: [256, 256]
-  center_crop: null
-  normalization: imagenet
+  transform: null
   train_batch_size: 32
   eval_batch_size: 32
   num_workers: 8
   task: segmentation
-  transform_config_train: null
-  transform_config_eval: null
+  train_transform: null
+  eval_transform: null
   test_split_mode: from_dir
   test_split_ratio: 0.2
   val_split_mode: same_as_test

--- a/configs/data/mvtec_3d.yaml
+++ b/configs/data/mvtec_3d.yaml
@@ -3,13 +3,12 @@ init_args:
   root: ./datasets/MVTec3D
   category: "bagel"
   image_size: [256, 256]
-  center_crop: null
-  normalization: imagenet
+  transform: null
   train_batch_size: 32
   eval_batch_size: 32
   num_workers: 8
-  transform_config_train: null
-  transform_config_eval: null
+  train_transform: null
+  eval_transform: null
   test_split_mode: from_dir
   test_split_ratio: 0.2
   val_split_mode: same_as_test

--- a/configs/data/shanghaitec.yaml
+++ b/configs/data/shanghaitec.yaml
@@ -6,13 +6,12 @@ init_args:
   frames_between_clips: 1
   target_frame: LAST
   image_size: [256, 256]
-  center_crop: null
-  normalization: imagenet
+  transform: null
   train_batch_size: 32
   eval_batch_size: 32
   num_workers: 8
-  transform_config_train: null
-  transform_config_eval: null
+  train_transform: null
+  eval_transform: null
   val_split_mode: FROM_TEST
   val_split_ratio: 0.5
   seed: null

--- a/configs/data/ucsd_ped.yaml
+++ b/configs/data/ucsd_ped.yaml
@@ -6,13 +6,12 @@ init_args:
   frames_between_clips: 10
   target_frame: LAST
   image_size: [256, 256]
-  center_crop: null
-  normalization: imagenet
+  transform: null
   train_batch_size: 8
   eval_batch_size: 1
   num_workers: 8
-  transform_config_train: null
-  transform_config_eval: null
+  train_transform: null
+  eval_transform: null
   val_split_mode: FROM_TEST
   val_split_ratio: 0.5
   seed: null

--- a/configs/data/visa.yaml
+++ b/configs/data/visa.yaml
@@ -3,13 +3,12 @@ init_args:
   root: "./datasets/visa"
   category: "capsules"
   image_size: [256, 256]
-  center_crop: null
-  normalization: imagenet
+  transform: null
   train_batch_size: 32
   eval_batch_size: 32
   num_workers: 8
-  transform_config_train: null
-  transform_config_eval: null
+  train_transform: null
+  eval_transform: null
   test_split_mode: from_dir
   test_split_ratio: 0.2
   val_split_mode: same_as_test


### PR DESCRIPTION
## 📝 Description

- 🛠️ Fixes #2031

There is a mismatch between some data config keys and `AnomalibDataModule` [init parameters](https://github.com/openvinotoolkit/anomalib/blob/f396dd4ab6a40b7b2f95004278d328fff18c999e/src/anomalib/data/base/datamodule.py#L78C9-L78C17) for all datasets. 
It looks like `normalization` and `center_crop` were replaced by more general `transform`, `transform_config_train` and `transform_config_eval` were renamed to `train_transform` and `eval_transform`, respectively.

I changed this in all data config files, now it is possible to start the training using these configs.

## ✨ Changes

Select what type of change your PR is:

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
