### PR TITLE
🐞 Fix Rich Progress with Patchcore Training

### DIFF
--- a/src/anomalib/engine/engine.py
+++ b/src/anomalib/engine/engine.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 
 import torch
-from lightning.pytorch.callbacks import Callback
+from lightning.pytorch.callbacks import Callback, RichModelSummary, RichProgressBar
 from lightning.pytorch.loggers import Logger
 from lightning.pytorch.trainer import Trainer
 from lightning.pytorch.utilities.types import _EVALUATE_OUTPUT, _PREDICT_OUTPUT, EVAL_DATALOADERS, TRAIN_DATALOADERS
@@ -406,7 +406,7 @@ class Engine:
 
     def _setup_anomalib_callbacks(self) -> None:
         """Set up callbacks for the trainer."""
-        _callbacks: list[Callback] = []
+        _callbacks: list[Callback] = [RichProgressBar(), RichModelSummary()]
 
         # Add ModelCheckpoint if it is not in the callbacks list.
         has_checkpoint_callback = any(isinstance(c, ModelCheckpoint) for c in self._cache.args["callbacks"])

--- a/src/anomalib/loggers/mlflow.py
+++ b/src/anomalib/loggers/mlflow.py
@@ -7,11 +7,7 @@ from lightning.pytorch.loggers.mlflow import MLFlowLogger
 from lightning.pytorch.utilities import rank_zero_only
 from matplotlib.figure import Figure
 
-from anomalib.utils.exceptions.imports import try_import
-
 from .base import ImageLoggerBase
-
-try_import("mlflow")
 
 
 class AnomalibMLFlowLogger(ImageLoggerBase, MLFlowLogger):

--- a/src/anomalib/models/components/sampling/k_center_greedy.py
+++ b/src/anomalib/models/components/sampling/k_center_greedy.py
@@ -8,10 +8,10 @@ Returns points that minimizes the maximum distance of any point to a center.
 # SPDX-License-Identifier: Apache-2.0
 
 import torch
-from rich.progress import track
 from torch.nn import functional as F  # noqa: N812
 
 from anomalib.models.components.dimensionality_reduction import SparseRandomProjection
+from anomalib.utils.rich import safe_track
 
 
 class KCenterGreedy:
@@ -98,7 +98,7 @@ class KCenterGreedy:
 
         selected_coreset_idxs: list[int] = []
         idx = int(torch.randint(high=self.n_observations, size=(1,)).item())
-        for _ in track(range(self.coreset_size), description="Selecting Coreset Indices."):
+        for _ in safe_track(sequence=range(self.coreset_size), description="Selecting Coreset Indices."):
             self.update_distances(cluster_centers=[idx])
             idx = self.get_new_idx()
             if idx in selected_idxs:

--- a/src/anomalib/utils/rich.py
+++ b/src/anomalib/utils/rich.py
@@ -1,0 +1,47 @@
+"""Custom rich methods."""
+
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Generator, Iterable
+from typing import TYPE_CHECKING, Any
+
+from rich import get_console
+from rich.progress import track
+
+if TYPE_CHECKING:
+    from rich.live import Live
+
+
+class CacheRichLiveState:
+    """Cache the live state of the console.
+
+    Note: This is a bit dangerous as it accesses private attributes of the console.
+    Use this with caution.
+    """
+
+    def __init__(self) -> None:
+        self.console = get_console()
+        self.live: "Live" | None = None
+
+    def __enter__(self) -> None:
+        """Save the live state of the console."""
+        # Need to access private attribute to get the live state
+        with self.console._lock:  # noqa: SLF001
+            self.live = self.console._live  # noqa: SLF001
+            self.console.clear_live()
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:  # noqa: ANN401
+        """Restore the live state of the console."""
+        if self.live:
+            self.console.clear_live()
+            self.console.set_live(self.live)
+
+
+def safe_track(*args, **kwargs) -> Generator[Iterable, Any, Any]:
+    """Wraps ``rich.progress.track`` with a context manager to cache the live state.
+
+    For parameters look at ``rich.progress.track``.
+    """
+    with CacheRichLiveState():
+        yield from track(*args, **kwargs)


### PR DESCRIPTION
## 📝 Description

- Since coreset subsampling uses `track` from `rich`, it breaks when we use any other progress bar. This caches the `LiveDisplay` before using `track` in subsampling.

## ✨ Changes

Select what type of change your PR is:

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
