### PR TITLE
Remove pkg_resources imports and use packaging instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Remove deprecated `pkg_resources` dependencies, install `packaging` instead by @davnn in (<https://github.com/openvinotoolkit/anomalib/pull/2082>)
 - WinCLIP: set device in text embedding collection and apply forward pass with no grad, by @djdameln in https://github.com/openvinotoolkit/anomalib/pull/1984
 - 🔨 Move all export functionalities to AnomalyModule as base methods by @thinhngo-x in (<https://github.com/openvinotoolkit/anomalib/pull/1803>)
 - Remove unnecessary jsonargparse dependencies by @davnn in (<https://github.com/openvinotoolkit/anomalib/pull/2046>)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "jsonargparse[signatures]>=4.27.7",
     "docstring_parser",     # CLI help-formatter
     "rich_argparse",        # CLI help-formatter
+    "packaging"
 ]
 
 [project.optional-dependencies]

--- a/src/anomalib/cli/install.py
+++ b/src/anomalib/cli/install.py
@@ -5,7 +5,7 @@
 
 import logging
 
-from pkg_resources import Requirement
+from packaging.requirements import Requirement
 from rich.console import Console
 from rich.logging import RichHandler
 

--- a/src/anomalib/cli/utils/installation.py
+++ b/src/anomalib/cli/utils/installation.py
@@ -13,7 +13,7 @@ from importlib.metadata import requires
 from pathlib import Path
 from warnings import warn
 
-from pkg_resources import Requirement
+from packaging.requirements import Requirement
 
 AVAILABLE_TORCH_VERSIONS = {
     "2.0.0": {"torchvision": "0.15.1", "cuda": ("11.7", "11.8")},
@@ -293,7 +293,7 @@ def add_hardware_suffix_to_torch(
             Defaults to False.
 
     Examples:
-        >>> from pkg_resources import Requirement
+        >>> from packaging.requirements import Requirement
         >>> req = "torch>=1.13.0, <=2.0.1"
         >>> requirement = Requirement.parse(req)
         >>> requirement.name, requirement.specs
@@ -364,7 +364,7 @@ def get_torch_install_args(requirement: str | Requirement) -> list[str]:
         RuntimeError: If the OS is not supported.
 
     Example:
-        >>> from pkg_resources import Requirement
+        >>> from packaging.requirements import Requirement
         >>> requriment = "torch>=1.13.0"
         >>> get_torch_install_args(requirement)
         ['--extra-index-url', 'https://download.pytorch.org/whl/cpu',

--- a/src/anomalib/models/video/ai_vad/clip/clip.py
+++ b/src/anomalib/models/video/ai_vad/clip/clip.py
@@ -18,7 +18,7 @@ from urllib.parse import urlparse
 import requests
 import torch
 from PIL import Image
-from pkg_resources import packaging
+from packaging import version
 from torchvision.transforms import CenterCrop, Compose, Normalize, Resize, ToTensor
 from tqdm import tqdm
 
@@ -33,7 +33,7 @@ except ImportError:
     BICUBIC = Image.BICUBIC
 
 
-if packaging.version.parse(torch.__version__) < packaging.version.parse("1.7.1"):
+if version.parse(torch.__version__) < version.parse("1.7.1"):
     msg = "PyTorch version 1.7.1 or higher is recommended"
     logger.warn(msg)
 

--- a/tests/unit/cli/test_installation.py
+++ b/tests/unit/cli/test_installation.py
@@ -8,7 +8,7 @@ import tempfile
 from pathlib import Path
 
 import pytest
-from pkg_resources import Requirement
+from packaging.requirements import Requirement
 from pytest_mock import MockerFixture
 
 from anomalib.cli.utils.installation import (


### PR DESCRIPTION
## 📝 Description

The ``pkg_resources`` module is deprecated and does not export the required symbols in newer versions. It is advised to use ``packaging`` or ``importlib`` instead. Because we only rely on functionality present in ``packaging``, the change from ``pkg_resources`` to ``packaging`` should be straightforward.

## ✨ Changes

Select what type of change your PR is:

- [ x ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ x ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ - ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ - ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
