### PR TITLE
fix winclip openvino inference output without mask

### DIFF
--- a/src/anomalib/models/image/winclip/lightning_model.py
+++ b/src/anomalib/models/image/winclip/lightning_model.py
@@ -125,7 +125,7 @@ class WinClip(AnomalyModule):
     def validation_step(self, batch: dict[str, str | torch.Tensor], *args, **kwargs) -> dict:
         """Validation Step of WinCLIP."""
         del args, kwargs  # These variables are not used.
-        batch["pred_scores"], batch["anomaly_maps"] = self.model(batch["image"])
+        batch["anomaly_maps"], batch["pred_scores"] = self.model(batch["image"])
         return batch
 
     @property

--- a/src/anomalib/models/image/winclip/torch_model.py
+++ b/src/anomalib/models/image/winclip/torch_model.py
@@ -250,7 +250,7 @@ class WinClipModel(DynamicBufferMixin, BufferListMixin, nn.Module):
             size=batch.shape[-2:],
             mode="bilinear",
         )
-        return image_scores, pixel_scores.squeeze(1)
+        return pixel_scores.squeeze(1), image_scores
 
     def _compute_zero_shot_scores(
         self,


### PR DESCRIPTION
## 📝 Description

WinClip OpenVINO Inference output is only the classification score.
- 🛠️ Fixes #1641

## ✨ Changes

Select what type of change your PR is:

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
