### PR TITLE
POC: Use dataclasses for model in- and outputs

### DIFF
--- a/src/anomalib/callbacks/metrics.py
+++ b/src/anomalib/callbacks/metrics.py
@@ -192,7 +192,7 @@ class _MetricsCallback(Callback):
             for key, value in output.items():
                 output[key] = self._outputs_to_device(value)
         elif isinstance(output, BatchItem):
-            output = BatchItem(**self._outputs_to_device(asdict(output)))
+            output = output.__class__(**self._outputs_to_device(asdict(output)))
         elif isinstance(output, torch.Tensor):
             output = output.to(self.device)
         return output

--- a/src/anomalib/callbacks/normalization/min_max_normalization.py
+++ b/src/anomalib/callbacks/normalization/min_max_normalization.py
@@ -55,12 +55,12 @@ class _MinMaxNormalizationCallback(NormalizationCallback):
         """Call when the validation batch ends, update the min and max observed values."""
         del trainer, batch, batch_idx, dataloader_idx  # These variables are not used.
 
-        if "anomaly_maps" in outputs:
-            pl_module.normalization_metrics(outputs["anomaly_maps"])
-        elif "box_scores" in outputs:
-            pl_module.normalization_metrics(torch.cat(outputs["box_scores"]))
-        elif "pred_scores" in outputs:
-            pl_module.normalization_metrics(outputs["pred_scores"])
+        if outputs.anomaly_map is not None:
+            pl_module.normalization_metrics(outputs.anomaly_map)
+        elif outputs.box_scores is not None:
+            pl_module.normalization_metrics(torch.cat(outputs.box_scores))
+        elif outputs.pred_score is not None:
+            pl_module.normalization_metrics(outputs.pred_score)
         else:
             msg = "No values found for normalization, provide anomaly maps, bbox scores, or image scores"
             raise ValueError(msg)
@@ -99,11 +99,11 @@ class _MinMaxNormalizationCallback(NormalizationCallback):
         image_threshold = pl_module.image_threshold.value.cpu()
         pixel_threshold = pl_module.pixel_threshold.value.cpu()
         stats = pl_module.normalization_metrics.cpu()
-        if "pred_scores" in outputs:
-            outputs["pred_scores"] = normalize(outputs["pred_scores"], image_threshold, stats.min, stats.max)
-        if "anomaly_maps" in outputs:
-            outputs["anomaly_maps"] = normalize(outputs["anomaly_maps"], pixel_threshold, stats.min, stats.max)
-        if "box_scores" in outputs:
-            outputs["box_scores"] = [
-                normalize(scores, pixel_threshold, stats.min, stats.max) for scores in outputs["box_scores"]
+        if outputs.pred_score is not None:
+            outputs.pred_score = normalize(outputs.pred_score, image_threshold, stats.min, stats.max)
+        if outputs.anomaly_map is not None:
+            outputs.anomaly_map = normalize(outputs.anomaly_map, pixel_threshold, stats.min, stats.max)
+        if outputs.box_scores is not None:
+            outputs.box_scores = [
+                normalize(scores, pixel_threshold, stats.min, stats.max) for scores in outputs.box_scores
             ]

--- a/src/anomalib/callbacks/thresholding.py
+++ b/src/anomalib/callbacks/thresholding.py
@@ -182,7 +182,7 @@ class _ThresholdCallback(Callback):
             for key, value in output.items():
                 output[key] = self._outputs_to_cpu(value)
         elif isinstance(output, BatchItem):
-            output = BatchItem(**self._outputs_to_cpu(asdict(output)))
+            output = output.__class__(**self._outputs_to_cpu(asdict(output)))
         elif isinstance(output, torch.Tensor):
             output = output.cpu()
         return output

--- a/src/anomalib/data/base/datamodule.py
+++ b/src/anomalib/data/base/datamodule.py
@@ -40,16 +40,16 @@ def collate_fn(batch: list[BatchItem]) -> dict[str, Any]:
         dict[str, Any]: Dictionary containing the collated batch information.
     """
     # convert to list of dicts
-    batch = [asdict(item) for item in batch]
-    elem = batch[0]  # sample an element from the batch to check the type.
+    batch_dict = [asdict(item) for item in batch]
+    elem = batch_dict[0]  # sample an element from the batch to check the type.
     out_dict = {}
     # if isinstance(elem, dict):
     if "boxes" in elem:
         # collate boxes as list
-        out_dict["boxes"] = [item.pop("boxes") for item in batch]
+        out_dict["boxes"] = [item.pop("boxes") for item in batch_dict]
     # collate other data normally
     out_dict.update({key: default_collate([item[key] for item in batch]) for key in elem if elem[key] is not None})
-    return BatchItem(**out_dict)
+    return batch[0].__class__(**out_dict)
     # return default_collate(batch)
 
 

--- a/src/anomalib/data/base/dataset.py
+++ b/src/anomalib/data/base/dataset.py
@@ -17,6 +17,7 @@ from torchvision.transforms.v2 import Transform
 from torchvision.tv_tensors import Mask
 
 from anomalib import TaskType
+from anomalib.dataclasses import BatchItem
 from anomalib.data.utils import LabelName, masks_to_boxes, read_image, read_mask
 
 _EXPECTED_COLUMNS_CLASSIFICATION = ["image_path", "split"]
@@ -189,7 +190,14 @@ class AnomalibDataset(Dataset, ABC):
             msg = f"Unknown task type: {self.task}"
             raise ValueError(msg)
 
-        return item
+        # return item
+        return BatchItem(
+            image=item["image"],
+            gt_mask=item["mask"],
+            gt_label=label_index,
+            image_path=image_path,
+            mask_path=mask_path,
+        )
 
     def __add__(self, other_dataset: "AnomalibDataset") -> "AnomalibDataset":
         """Concatenate this dataset with another dataset.

--- a/src/anomalib/data/base/dataset.py
+++ b/src/anomalib/data/base/dataset.py
@@ -17,7 +17,7 @@ from torchvision.transforms.v2 import Transform
 from torchvision.tv_tensors import Mask
 
 from anomalib import TaskType
-from anomalib.dataclasses import BatchItem
+from anomalib.dataclasses import ImageBatch
 from anomalib.data.utils import LabelName, masks_to_boxes, read_image, read_mask
 
 _EXPECTED_COLUMNS_CLASSIFICATION = ["image_path", "split"]
@@ -191,7 +191,7 @@ class AnomalibDataset(Dataset, ABC):
             raise ValueError(msg)
 
         # return item
-        return BatchItem(
+        return ImageBatch(
             image=item["image"],
             gt_mask=item["mask"],
             gt_label=label_index,

--- a/src/anomalib/data/utils/video.py
+++ b/src/anomalib/data/utils/video.py
@@ -12,6 +12,8 @@ import cv2
 import torch
 from torchvision.datasets.video_utils import VideoClips
 
+from anomalib.dataclasses import VideoBatch
+
 
 class ClipsIndexer(VideoClips, ABC):
     """Extension of torchvision's VideoClips class that also returns the masks for each clip.
@@ -60,13 +62,13 @@ class ClipsIndexer(VideoClips, ABC):
         video_path = self.video_paths[video_idx]
         clip_pts = self.clips[video_idx][clip_idx]
 
-        return {
-            "image": clip,
-            "mask": self.get_mask(idx),
-            "video_path": video_path,
-            "frames": clip_pts,
-            "last_frame": self.last_frame_idx(video_idx),
-        }
+        return VideoBatch(
+            image=clip,
+            gt_mask=self.get_mask(idx),
+            video_path=video_path,
+            frames=clip_pts,
+            last_frame=self.last_frame_idx(video_idx),
+        )
 
 
 def convert_video(input_path: Path, output_path: Path, codec: str = "MP4V") -> None:

--- a/src/anomalib/dataclasses.py
+++ b/src/anomalib/dataclasses.py
@@ -4,42 +4,55 @@ from dataclasses import dataclass, asdict
 import warnings
 from pathlib import Path
 
+
 @dataclass
 class BatchItem:
-    image: torch.Tensor | None = None
-    gt_label: int | None = None
-    pred_label: int | None = None
+    """Base class for dataclass objects that are passed between steps in the pipeline."""
+    def __getitem__(self, key: str) -> torch.Tensor:
+        try:
+            return asdict(self)[key]
+        except KeyError:
+            msg = f"{key} is not a valid key for StepOutput. Valid keys are: {list(asdict(self).keys())}"
+            raise KeyError(msg)
+        
+    def __setitem__(self, key, value):
+        if hasattr(self, key):
+            setattr(self, key, value)
+        else:
+            msg = f"{key} is not a valid key for StepOutput. Valid keys are: {list(asdict(self).keys())}"
+            raise KeyError(msg)
+    
+
+@dataclass
+class PredictBatch(BatchItem):
+    """Base class for storing the prediction results of a model."""
+
     pred_score: float | None = None
-    gt_mask: torch.Tensor | None = None
-    pred_mask: torch.Tensor | None = None
+    pred_label: int | None = None
     anomaly_map: torch.Tensor | None = None
-    image_path: Path | None = None
-    mask_path: Path | None = None
+    pred_mask: torch.Tensor | None = None
     pred_boxes: torch.Tensor | None = None
     box_scores: torch.Tensor | None = None
     box_labels: torch.Tensor | None = None
-    video_path: Path | None = None
-    original_image: torch.Tensor | None = None
+
+
+@dataclass
+class InputBatch(BatchItem):
+    """Base class for storing the input data of a model."""
+
+    image: torch.Tensor | None = None
+
+    gt_label: int | None = None
+    gt_mask: torch.Tensor | None = None
     gt_boxes: torch.Tensor | None = None
 
-    # def __getitem__(self, key: str) -> torch.Tensor:
-    #     try:
-    #         return asdict(self)[key]
-    #     except KeyError:
-    #         msg = f"{key} is not a valid key for StepOutput. Valid keys are: {list(asdict(self).keys())}"
-    #         raise KeyError(msg)
-        
-    # def __setitem__(self, key, value):
-    #     if hasattr(self, key):
-    #         setattr(self, key, value)
-    #     else:
-    #         msg = f"{key} is not a valid key for StepOutput. Valid keys are: {list(asdict(self).keys())}"
-    #         raise KeyError(msg)
+    mask_path: Path | None = None
     
     @property
     def mask(self) -> torch.Tensor:
+        """Legacy getter for gt_mask. Will be removed in v1.2."""
         warnings.warn(
-            "The `mask` attribute is deprecated and will be removed in the next release. "
+            "The `mask` attribute is deprecated and will be removed in v1.2. "
             "Please use `pred_mask` instead.",
             DeprecationWarning,
         )
@@ -47,9 +60,26 @@ class BatchItem:
     
     @mask.setter
     def mask(self, value: torch.Tensor) -> None:
+        """Legacy setter for gt_mask. Will be removed in v1.2."""
         warnings.warn(
-            "The `mask` attribute is deprecated and will be removed in the next release. "
+            "The `mask` attribute is deprecated and will be removed in v1.2. "
             "Please use `pred_mask` instead.",
             DeprecationWarning,
         )
         self.gt_mask = value
+
+
+@dataclass
+class ImageBatch(InputBatch, PredictBatch):
+    """Dataclass for storing image data."""
+
+    image_path: Path | None = None
+
+@dataclass
+class VideoBatch(InputBatch, PredictBatch):
+    """Dataclass for storing video data."""
+
+    video_path: Path | None = None
+    original_image: torch.Tensor | None = None
+    frames: torch.Tensor | None = None
+    last_frame: int | None = None

--- a/src/anomalib/dataclasses.py
+++ b/src/anomalib/dataclasses.py
@@ -1,0 +1,55 @@
+import torch
+
+from dataclasses import dataclass, asdict
+import warnings
+from pathlib import Path
+
+@dataclass
+class BatchItem:
+    image: torch.Tensor | None = None
+    gt_label: int | None = None
+    pred_label: int | None = None
+    pred_score: float | None = None
+    gt_mask: torch.Tensor | None = None
+    pred_mask: torch.Tensor | None = None
+    anomaly_map: torch.Tensor | None = None
+    image_path: Path | None = None
+    mask_path: Path | None = None
+    pred_boxes: torch.Tensor | None = None
+    box_scores: torch.Tensor | None = None
+    box_labels: torch.Tensor | None = None
+    video_path: Path | None = None
+    original_image: torch.Tensor | None = None
+    gt_boxes: torch.Tensor | None = None
+
+    # def __getitem__(self, key: str) -> torch.Tensor:
+    #     try:
+    #         return asdict(self)[key]
+    #     except KeyError:
+    #         msg = f"{key} is not a valid key for StepOutput. Valid keys are: {list(asdict(self).keys())}"
+    #         raise KeyError(msg)
+        
+    # def __setitem__(self, key, value):
+    #     if hasattr(self, key):
+    #         setattr(self, key, value)
+    #     else:
+    #         msg = f"{key} is not a valid key for StepOutput. Valid keys are: {list(asdict(self).keys())}"
+    #         raise KeyError(msg)
+    
+    @property
+    def mask(self) -> torch.Tensor:
+        warnings.warn(
+            "The `mask` attribute is deprecated and will be removed in the next release. "
+            "Please use `pred_mask` instead.",
+            DeprecationWarning,
+        )
+        return self.gt_mask
+    
+    @mask.setter
+    def mask(self, value: torch.Tensor) -> None:
+        warnings.warn(
+            "The `mask` attribute is deprecated and will be removed in the next release. "
+            "Please use `pred_mask` instead.",
+            DeprecationWarning,
+        )
+        self.gt_mask = value

--- a/src/anomalib/models/components/base/anomaly_module.py
+++ b/src/anomalib/models/components/base/anomaly_module.py
@@ -26,7 +26,7 @@ from .export_mixin import ExportMixin
 if TYPE_CHECKING:
     from lightning.pytorch.callbacks import Callback
     from torchmetrics import Metric
-
+    
 
 logger = logging.getLogger(__name__)
 

--- a/src/anomalib/models/video/ai_vad/lightning_model.py
+++ b/src/anomalib/models/video/ai_vad/lightning_model.py
@@ -113,7 +113,7 @@ class AiVad(MemoryBankMixin, AnomalyModule):
         """
         features_per_batch = self.model(batch["image"])
 
-        for features, video_path in zip(features_per_batch, batch["video_path"], strict=True):
+        for features, video_path in zip(features_per_batch, batch.video_path, strict=True):
             self.model.density_estimator.update(features, video_path)
             self.total_detections += len(next(iter(features.values())))
 
@@ -139,10 +139,10 @@ class AiVad(MemoryBankMixin, AnomalyModule):
         """
         del args, kwargs  # Unused arguments.
 
-        boxes, anomaly_scores, image_scores = self.model(batch["image"])
-        batch["pred_boxes"] = [box.int() for box in boxes]
-        batch["box_scores"] = [score.to(self.device) for score in anomaly_scores]
-        batch["pred_scores"] = torch.Tensor(image_scores).to(self.device)
+        boxes, anomaly_scores, image_scores = self.model(batch.image)
+        batch.pred_boxes = [box.int() for box in boxes]
+        batch.box_scores = [score.to(self.device) for score in anomaly_scores]
+        batch.pred_score = torch.Tensor(image_scores).to(self.device)
 
         return batch
 

--- a/src/anomalib/utils/visualization/image.py
+++ b/src/anomalib/utils/visualization/image.py
@@ -136,38 +136,38 @@ class ImageVisualizer(BaseVisualizer):
         Returns:
             Generator that yields a display-ready visualization for each image.
         """
-        batch_size = batch["image"].shape[0]
+        batch_size = batch.image.shape[0]
         for i in range(batch_size):
-            if "image_path" in batch:
-                height, width = batch["image"].shape[-2:]
-                image = (read_image(path=batch["image_path"][i]) * 255).astype(np.uint8)
+            if batch.image_path is not None:
+                height, width = batch.image.shape[-2:]
+                image = (read_image(path=batch.image_path[i]) * 255).astype(np.uint8)
                 image = cv2.resize(image, dsize=(width, height), interpolation=cv2.INTER_AREA)
-            elif "video_path" in batch:
-                height, width = batch["image"].shape[-2:]
-                image = batch["original_image"][i].squeeze().cpu().numpy()
+            elif batch.video_path is not None:
+                height, width = batch.image.shape[-2:]
+                image = batch.original_image[i].squeeze().cpu().numpy()
                 image = cv2.resize(image, dsize=(width, height), interpolation=cv2.INTER_AREA)
             else:
                 msg = "Batch must have either 'image_path' or 'video_path' defined."
                 raise KeyError(msg)
 
             file_name = None
-            if "image_path" in batch:
-                file_name = Path(batch["image_path"][i])
-            elif "video_path" in batch:
-                zero_fill = int(np.log10(batch["last_frame"][i])) + 1
-                suffix = f"{str(batch['frames'][i].int().item()).zfill(zero_fill)}.png"
-                file_name = Path(batch["video_path"][i]) / suffix
+            if batch.image_path is not None:
+                file_name = Path(batch.image_path[i])
+            elif batch.video_path is not None:
+                zero_fill = int(np.log10(batch.last_frame[i])) + 1
+                suffix = f"{str(batch.frames[i].int().item()).zfill(zero_fill)}.png"
+                file_name = Path(batch.video_path[i]) / suffix
 
             image_result = ImageResult(
                 image=image,
-                pred_score=batch["pred_scores"][i].cpu().numpy().item() if "pred_scores" in batch else None,
-                pred_label=batch["pred_labels"][i].cpu().numpy().item() if "pred_labels" in batch else None,
-                anomaly_map=batch["anomaly_maps"][i].cpu().numpy() if "anomaly_maps" in batch else None,
-                pred_mask=batch["pred_masks"][i].squeeze().int().cpu().numpy() if "pred_masks" in batch else None,
-                gt_mask=batch["mask"][i].squeeze().int().cpu().numpy() if "mask" in batch else None,
-                gt_boxes=batch["boxes"][i].cpu().numpy() if "boxes" in batch else None,
-                pred_boxes=batch["pred_boxes"][i].cpu().numpy() if "pred_boxes" in batch else None,
-                box_labels=batch["box_labels"][i].cpu().numpy() if "box_labels" in batch else None,
+                pred_score=batch.pred_score[i].cpu().numpy().item() if batch.pred_score is not None else None,
+                pred_label=batch.pred_label[i].cpu().numpy().item() if batch.pred_label is not None else None,
+                anomaly_map=batch.anomaly_map[i].cpu().numpy() if batch.anomaly_map is not None else None,
+                pred_mask=batch.pred_mask[i].squeeze().int().cpu().numpy() if batch.pred_mask is not None else None,
+                gt_mask=batch.gt_mask[i].squeeze().int().cpu().numpy() if batch.gt_mask is not None else None,
+                gt_boxes=batch.gt_boxes[i].cpu().numpy() if batch.gt_boxes is not None else None,
+                pred_boxes=batch.pred_boxes[i].cpu().numpy() if batch.pred_boxes is not None else None,
+                box_labels=batch.box_labels[i].cpu().numpy() if batch.box_labels is not None else None,
             )
             yield GeneratorResult(image=self.visualize_image(image_result), file_name=file_name)
 


### PR DESCRIPTION
## 📝 Description

- Initial implementation of dataclasses for model inputs and outputs, meant to collect feedback (DO NOT MERGE).
- Adds `ImageBatch` and `VideoBatch` dataclasses and base classes.
- `collate_fn` had to be updated to allow collating the dataclasses as batches.
- Backward compatibility is achieved by defining the `__getitem__` and `__setitem__` methods in the `BatchItem` base class and by adding prorties for renamed attributes (e.g. `mask` -> `gt_mask`).

## ✨ Changes

Select what type of change your PR is:

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
