### PR TITLE
fix: get MLFLOW_TRACKING_UTI from env variables as default

### DIFF
--- a/src/anomalib/loggers/mlflow.py
+++ b/src/anomalib/loggers/mlflow.py
@@ -2,6 +2,7 @@
 
 from typing import Literal
 
+import os
 import numpy as np
 from lightning.pytorch.loggers.mlflow import MLFlowLogger
 from lightning.pytorch.utilities import rank_zero_only
@@ -65,7 +66,7 @@ class AnomalibMLFlowLogger(ImageLoggerBase, MLFlowLogger):
         self,
         experiment_name: str | None = "anomalib_logs",
         run_name: str | None = None,
-        tracking_uri: str | None = None,
+        tracking_uri: str | None = os.getenv("MLFLOW_TRACKING_URI"),
         save_dir: str | None = "./mlruns",
         log_model: Literal[True, False, "all"] | None = False,
         prefix: str | None = "",

--- a/src/anomalib/loggers/mlflow.py
+++ b/src/anomalib/loggers/mlflow.py
@@ -1,5 +1,6 @@
 """MLFlow logger with add image interface."""
 
+import os
 from typing import Literal
 
 import numpy as np

--- a/src/anomalib/loggers/mlflow.py
+++ b/src/anomalib/loggers/mlflow.py
@@ -2,7 +2,6 @@
 
 from typing import Literal
 
-import os
 import numpy as np
 from lightning.pytorch.loggers.mlflow import MLFlowLogger
 from lightning.pytorch.utilities import rank_zero_only


### PR DESCRIPTION

## 📝 Description

- In `AnomalibMLFlowLogger`, `tracking_uri` was set to None, which was overriding the parameter in the underlying pytorch `MLFlowLogger` so you could never log in to a remote server. This fixes it.
- 🛠️ Fixes # (NO EXISTING ISSUE YET)

## ✨ Changes

Select what type of change your PR is:

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
