### PR TITLE
Fix image-level heatmap normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fix image-level heatmap normalization in visualizer by @djdameln in https://github.com/openvinotoolkit/anomalib/pull/2131
 - 🐞 Fix dimensionality mismatch issue caused by the new kornia version by @samet-akcay in https://github.com/openvinotoolkit/anomalib/pull/1944
 - 🐞 Fix DFM PyTorch inference by @adrianboguszewski in https://github.com/openvinotoolkit/anomalib/pull/1952
 - 🐞 Fix anomaly map shape to also work with tiling by @blaz-r in https://github.com/openvinotoolkit/anomalib/pull/1959

--- a/src/anomalib/engine/engine.py
+++ b/src/anomalib/engine/engine.py
@@ -434,7 +434,7 @@ class Engine:
 
         _callbacks.append(
             _VisualizationCallback(
-                visualizers=ImageVisualizer(task=self.task),
+                visualizers=ImageVisualizer(task=self.task, normalize=self.normalization == NormalizationMethod.NONE),
                 save=True,
                 root=self._cache.args["default_root_dir"] / "images",
             ),

--- a/src/anomalib/utils/visualization/image.py
+++ b/src/anomalib/utils/visualization/image.py
@@ -168,6 +168,7 @@ class ImageVisualizer(BaseVisualizer):
                 gt_boxes=batch["boxes"][i].cpu().numpy() if "boxes" in batch else None,
                 pred_boxes=batch["pred_boxes"][i].cpu().numpy() if "pred_boxes" in batch else None,
                 box_labels=batch["box_labels"][i].cpu().numpy() if "box_labels" in batch else None,
+                normalize=self.normalize,
             )
             yield GeneratorResult(image=self.visualize_image(image_result), file_name=file_name)
 


### PR DESCRIPTION
## 📝 Description

- Fix anomaly map normalization when `NormalizationMode` is set to `NONE`
- When dataset-level normalization is disabled, the visualizer should normalize the heatmaps at the image-level.

before
![image](https://github.com/openvinotoolkit/anomalib/assets/26067904/074132c1-5109-4043-9232-e175c5f747f9)

after
![image](https://github.com/openvinotoolkit/anomalib/assets/26067904/c726eab8-da2f-4dc3-ae15-fdddfff021a3)


## ✨ Changes

Select what type of change your PR is:

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
