### PR TITLE
Reset min_max normalization values at the start of validation epoch

### DIFF
--- a/src/anomalib/callbacks/normalization/min_max_normalization.py
+++ b/src/anomalib/callbacks/normalization/min_max_normalization.py
@@ -43,6 +43,18 @@ class _MinMaxNormalizationCallback(NormalizationCallback):
             if metric is not None:
                 metric.set_threshold(0.5)
 
+    def on_validation_batch_start(self,
+        trainer: Trainer,
+        pl_module: AnomalyModule,
+        outputs: STEP_OUTPUT,
+        batch: Any,  # noqa: ANN401
+        dataloader_idx: int = 0,
+    ) -> None:
+        """Call when the validation batch starts, reset the min and max to default values
+        to make sure that irrelevant values from previous epochs are not used."""
+        del trainer, batch, dataloader_idx  # These variables are not used.
+        pl_module.normalization_metrics.reset()
+
     def on_validation_batch_end(
         self,
         trainer: Trainer,


### PR DESCRIPTION
## 📝 Description

Currently, min_max values for normalization are updated every validation epoch. This update keeps irrelevant values from previous epochs by comparing new and old ones:
`self.max = torch.max(self.max, torch.max(predictions))`

It seems like it does not affect most of the models, but with at least EfficientAD, the final anomaly maps after training are normalized the wrong way (see #2139 or this [discussion](https://github.com/openvinotoolkit/anomalib/discussions/1647)).

This fix resets min_max values at the beginning of every validation epoch to ensure that only values from the recent one will be used for normalization.

🛠️ Fixes #2027, thank you @CarlosNacher for pointing this problem out! Partially fixes #2139.

## ✨ Changes

Select what type of change your PR is:

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
