### PR TITLE
Fix duplicated size parameter value in ExportableCenterCrop

### DIFF
--- a/src/anomalib/data/transforms/center_crop.py
+++ b/src/anomalib/data/transforms/center_crop.py
@@ -9,7 +9,7 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Any
+from typing import Any, Sequence
 
 import torch
 from torch.nn.functional import pad
@@ -77,9 +77,9 @@ class ExportableCenterCrop(Transform):
         size (int | tuple[int, int]): Desired output size of the crop.
     """
 
-    def __init__(self, size: int | tuple[int, int]) -> None:
+    def __init__(self, size: int | Sequence[int, int]) -> None:
         super().__init__()
-        self.size = list(size) if isinstance(size, tuple) else [size, size]
+        self.size = list(size) if isinstance(size, Sequence) else [size, size]
 
     def _transform(self, inpt: torch.Tensor, params: dict[str, Any]) -> torch.Tensor:
         """Apply the transform."""


### PR DESCRIPTION

## 📝 Description

When you export an anomalib's model that have the `CenterCrop` transform in it (`torchvision.transforms.v2.CenterCrop`), anomalib automatically replaces that `CenterCrop` transform with `ExportableCenterCrop` for ONNX compatibility reasons:
![image](https://github.com/user-attachments/assets/51b9631c-9078-4531-a3b2-d54f4126015b)
![image](https://github.com/user-attachments/assets/efca91e0-cfa5-4a9b-b89c-02280d95b531)

Okay, but when you try to use that model within an `TorchInferencer` ,for example, you will get this error when trying the `.predict()` method:

![image](https://github.com/user-attachments/assets/72d8d50e-23e7-4792-932d-52019d5e6ffe)

And the reason is that the `ExportableCenterCrop` transform checks wether the `size` parameter is a tuple, and if not repeats the parameter twice in a list. But, normally, the `size` parameter of torchvision CenterCrop is internally represented as a **`list` and not as a `tuple`**. 

![image](https://github.com/user-attachments/assets/ab49ee96-4244-4c29-aee2-346296280881)

The proposed solution just changes that line of code (`isinstance` comprobation) to pass either with a tuple or a list (`Sequence` type object, as typed in [original torchvision CenterCrop transform](https://pytorch.org/vision/main/generated/torchvision.transforms.v2.CenterCrop.html) ).

- 🛠️ No submitted Issue. Described here itself.

## ✨ Changes

Select what type of change your PR is:

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
