### PR TITLE
Allow passing metrics objects directly to `create_metrics_collection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
-- 🔨 Replace "./dtasets/BTech" to "./dtasets/BTech"
+- 🔨 Allow passing metrics objects directly to `create_metrics_collection` by @ashwinvaidya17 in https://github.com/openvinotoolkit/anomalib/pull/2212
+- 🔨 Replace "./dtasets/BTech" to "./datasets/BTech" by @samet-akcay in https://github.com/openvinotoolkit/anomalib/pull/2180
 
 ### Deprecated
 

--- a/tests/unit/metrics/test_create_metrics.py
+++ b/tests/unit/metrics/test_create_metrics.py
@@ -1,0 +1,45 @@
+"""Test metrics collection creation."""
+
+from torchmetrics.classification import Accuracy
+
+from anomalib.metrics import AUPRO, create_metric_collection
+
+
+def test_string_initialization() -> None:
+    """Pass metrics as a list of string."""
+    metrics_list = ["AUROC", "AUPR"]
+    collection = create_metric_collection(metrics_list, prefix=None)
+    assert len(collection) == 2
+    assert "AUROC" in collection
+    assert "AUPR" in collection
+
+
+def test_dict_initialization() -> None:
+    """Pass metrics as a dictionary."""
+    metrics_dict = {
+        "PixelWiseAUROC": {
+            "class_path": "anomalib.metrics.AUROC",
+            "init_args": {},
+        },
+        "Precision": {
+            "class_path": "torchmetrics.Precision",
+            "init_args": {"task": "binary"},
+        },
+    }
+    collection = create_metric_collection(metrics_dict, prefix=None)
+    assert len(collection) == 2
+    assert "PixelWiseAUROC" in collection
+    assert "Precision" in collection
+
+
+def test_metric_object_initialization() -> None:
+    """Pass metrics as a list of metric objects."""
+    metrics_list = [AUPRO(), Accuracy(task="binary")]
+    collection = create_metric_collection(metrics_list, prefix=None)
+    assert len(collection) == 2
+    assert "AUPRO" in collection
+    assert "BinaryAccuracy" in collection
+
+    collection = create_metric_collection(AUPRO(), prefix=None)
+    assert len(collection) == 1
+    assert "AUPRO" in collection


### PR DESCRIPTION
## 📝 Description

- Adds the ability to pass metric objects directly.
- Alternative to solution proposed in https://github.com/openvinotoolkit/anomalib/issues/2205

To test

```python
from torchmetrics.classification import Accuracy, Precision, Recall

from anomalib.data import MVTec
from anomalib.engine import Engine
from anomalib.models import Padim

if __name__ == "__main__":
    model = Padim()
    data = MVTec()
    engine = Engine(image_metrics=[Accuracy(task="binary"), Precision(task="binary"), Recall(task="binary")])
    engine.train(model, datamodule=data)
```

## ✨ Changes

Select what type of change your PR is:

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
