### PR TITLE
Refactor Lightning's `trainer.model` to `trainer.lightning_module`

### DIFF
--- a/src/anomalib/callbacks/checkpoint.py
+++ b/src/anomalib/callbacks/checkpoint.py
@@ -35,7 +35,7 @@ class ModelCheckpoint(LightningCheckpoint):
         Overrides the parent method to allow saving during both the ``FITTING`` and ``VALIDATING`` states, and to allow
         saving when the global step and last_global_step_saved are both 0 (only for zero-/few-shot models).
         """
-        is_zero_or_few_shot = trainer.model.learning_type in [LearningType.ZERO_SHOT, LearningType.FEW_SHOT]
+        is_zero_or_few_shot = trainer.lightning_module.learning_type in [LearningType.ZERO_SHOT, LearningType.FEW_SHOT]
         return (
             bool(trainer.fast_dev_run)  # disable checkpointing with fast_dev_run
             or trainer.state.fn not in [TrainerFn.FITTING, TrainerFn.VALIDATING]  # don't save anything during non-fit
@@ -52,7 +52,7 @@ class ModelCheckpoint(LightningCheckpoint):
         if self._save_on_train_epoch_end is not None:
             return self._save_on_train_epoch_end
 
-        if trainer.model.learning_type in [LearningType.ZERO_SHOT, LearningType.FEW_SHOT]:
+        if trainer.lightning_module.learning_type in [LearningType.ZERO_SHOT, LearningType.FEW_SHOT]:
             return False
 
         return super()._should_save_on_train_epoch_end(trainer)

--- a/src/anomalib/data/base/datamodule.py
+++ b/src/anomalib/data/base/datamodule.py
@@ -270,8 +270,8 @@ class AnomalibDataModule(LightningDataModule, ABC):
         """
         if self._train_transform:
             return self._train_transform
-        if getattr(self, "trainer", None) and self.trainer.model and self.trainer.model.transform:
-            return self.trainer.model.transform
+        if getattr(self, "trainer", None) and self.trainer.lightning_module and self.trainer.lightning_module.transform:
+            return self.trainer.lightning_module.transform
         if self.image_size:
             return Resize(self.image_size, antialias=True)
         return None
@@ -284,8 +284,8 @@ class AnomalibDataModule(LightningDataModule, ABC):
         """
         if self._eval_transform:
             return self._eval_transform
-        if getattr(self, "trainer", None) and self.trainer.model and self.trainer.model.transform:
-            return self.trainer.model.transform
+        if getattr(self, "trainer", None) and self.trainer.lightning_module and self.trainer.lightning_module.transform:
+            return self.trainer.lightning_module.transform
         if self.image_size:
             return Resize(self.image_size, antialias=True)
         return None

--- a/src/anomalib/engine/engine.py
+++ b/src/anomalib/engine/engine.py
@@ -183,7 +183,7 @@ class Engine:
         Returns:
             AnomalyModule: Anomaly model.
         """
-        if not self.trainer.model:
+        if not self.trainer.lightning_module:
             msg = "Trainer does not have a model assigned yet."
             raise UnassignedError(msg)
         return self.trainer.lightning_module

--- a/tests/unit/metrics/test_adaptive_threshold.py
+++ b/tests/unit/metrics/test_adaptive_threshold.py
@@ -55,5 +55,5 @@ def test_manual_threshold() -> None:
         devices=1,
     )
     engine.fit(model=model, datamodule=datamodule)
-    assert engine.trainer.model.image_metrics.F1Score.threshold == image_threshold
-    assert engine.trainer.model.pixel_metrics.F1Score.threshold == pixel_threshold
+    assert engine.trainer.lightning_module.image_metrics.F1Score.threshold == image_threshold
+    assert engine.trainer.lightning_module.pixel_metrics.F1Score.threshold == pixel_threshold


### PR DESCRIPTION
## 📝 Description

The `trainer.model` attribute is deprecated in newer versions of PyTorch Lightning. Using `trainer.lightning_module` is the recommended approach for accessing the `LightningModule` instance, which encapsulates our model, training logic, and related components.

- This pull request updates our codebase to align with the latest best practices in PyTorch Lightning by replacing all instances of trainer.model with `trainer.lightning_module`.

## ✨ Changes

Replaced all occurrences of trainer.model with trainer.lightning_module

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
