### PR TITLE
Add check before loading metrics data from checkpoint

### DIFF
--- a/src/anomalib/models/components/base/anomaly_module.py
+++ b/src/anomalib/models/components/base/anomaly_module.py
@@ -168,20 +168,19 @@ class AnomalyModule(ExportMixin, pl.LightningModule, ABC):
         if "pixel_threshold_class" in state_dict:
             self.pixel_threshold = self._get_instance(state_dict, "pixel_threshold_class")
 
-        if "anomaly_maps_normalization_class" in state_dict:
-            self.anomaly_maps_normalization_metrics = self._get_instance(state_dict, "anomaly_maps_normalization_class")
-        if "box_scores_normalization_class" in state_dict:
-            self.box_scores_normalization_metrics = self._get_instance(state_dict, "box_scores_normalization_class")
+        # check only for pred score normalization metrics, because if this one is present, all others are too
         if "pred_scores_normalization_class" in state_dict:
+            self.box_scores_normalization_metrics = self._get_instance(state_dict, "box_scores_normalization_class")
+            self.anomaly_maps_normalization_metrics = self._get_instance(state_dict, "anomaly_maps_normalization_class")
             self.pred_scores_normalization_metrics = self._get_instance(state_dict, "pred_scores_normalization_class")
 
-        self.normalization_metrics = MetricCollection(
-            {
-                "anomaly_maps": self.anomaly_maps_normalization_metrics,
-                "box_scores": self.box_scores_normalization_metrics,
-                "pred_scores": self.pred_scores_normalization_metrics,
-            },
-        )
+            self.normalization_metrics = MetricCollection(
+                {
+                    "anomaly_maps": self.anomaly_maps_normalization_metrics,
+                    "box_scores": self.box_scores_normalization_metrics,
+                    "pred_scores": self.pred_scores_normalization_metrics,
+                },
+            )
         # Used to load metrics if there is any related data in state_dict
         self._load_metrics(state_dict)
 


### PR DESCRIPTION
## 📝 Description

- This PR fixes a problem where AttributeError would occur if model, trained without normalization metrics, was loaded from checkpoint.
- 🛠️ Fixes #2253

## ✨ Changes

Select what type of change your PR is:

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
