### PR TITLE
Fix transforms for draem, dsr and rkde

### DIFF
--- a/src/anomalib/models/image/draem/lightning_model.py
+++ b/src/anomalib/models/image/draem/lightning_model.py
@@ -12,6 +12,7 @@ from typing import Any
 import torch
 from lightning.pytorch.utilities.types import STEP_OUTPUT
 from torch import nn
+from torchvision.transforms.v2 import Compose, Resize, Transform
 
 from anomalib import LearningType
 from anomalib.data.utils import Augmenter
@@ -150,3 +151,13 @@ class Draem(AnomalyModule):
             LearningType: Learning type of the model.
         """
         return LearningType.ONE_CLASS
+
+    @staticmethod
+    def configure_transforms(image_size: tuple[int, int] | None = None) -> Transform:
+        """Default transform for DRAEM. Normalization is not needed as the images are scaled to [0, 1] in Dataset."""
+        image_size = image_size or (256, 256)
+        return Compose(
+            [
+                Resize(image_size, antialias=True),
+            ],
+        )

--- a/src/anomalib/models/image/dsr/lightning_model.py
+++ b/src/anomalib/models/image/dsr/lightning_model.py
@@ -13,6 +13,7 @@ from typing import Any
 import torch
 from lightning.pytorch.utilities.types import STEP_OUTPUT, OptimizerLRScheduler
 from torch import Tensor
+from torchvision.transforms.v2 import Compose, Resize, Transform
 
 from anomalib import LearningType
 from anomalib.data.utils import DownloadInfo, download_and_extract
@@ -191,3 +192,13 @@ class Dsr(AnomalyModule):
             LearningType: Learning type of the model.
         """
         return LearningType.ONE_CLASS
+
+    @staticmethod
+    def configure_transforms(image_size: tuple[int, int] | None = None) -> Transform:
+        """Default transform for DSR. Normalization is not needed as the images are scaled to [0, 1] in Dataset."""
+        image_size = image_size or (256, 256)
+        return Compose(
+            [
+                Resize(image_size, antialias=True),
+            ],
+        )

--- a/src/anomalib/models/image/rkde/lightning_model.py
+++ b/src/anomalib/models/image/rkde/lightning_model.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import torch
 from lightning.pytorch.utilities.types import STEP_OUTPUT
+from torchvision.transforms.v2 import Compose, Resize, Transform
 
 from anomalib import LearningType
 from anomalib.models.components import AnomalyModule, MemoryBankMixin
@@ -143,3 +144,13 @@ class Rkde(MemoryBankMixin, AnomalyModule):
             LearningType: Learning type of the model.
         """
         return LearningType.ONE_CLASS
+
+    @staticmethod
+    def configure_transforms(image_size: tuple[int, int] | None = None) -> Transform:
+        """Default transform for RKDE."""
+        image_size = image_size or (240, 360)
+        return Compose(
+            [
+                Resize(image_size, antialias=True),
+            ],
+        )


### PR DESCRIPTION
## 📝 Description

- This PR adds `configure_transforms` method to dsr, draem and rkde. The method includes only resizing transformation. ImageNet normalization from default parent class method is skipped since these models don't use it.
- 🛠️ Fixes #1813

## ✨ Changes

Select what type of change your PR is:

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
