### PR TITLE
🐞 Defer OpenVINO import to avoid unnecessary warnings

### DIFF
--- a/src/anomalib/deploy/inferencers/openvino_inferencer.py
+++ b/src/anomalib/deploy/inferencers/openvino_inferencer.py
@@ -21,14 +21,6 @@ from .base_inferencer import Inferencer
 
 logger = logging.getLogger("anomalib")
 
-if find_spec("openvino") is not None:
-    import openvino as ov
-
-    if TYPE_CHECKING:
-        from openvino import CompiledModel
-else:
-    logger.warning("OpenVINO is not installed. Please install OpenVINO to use OpenVINOInferencer.")
-
 
 class OpenVINOInferencer(Inferencer):
     """OpenVINO implementation for the inference.
@@ -102,6 +94,11 @@ class OpenVINOInferencer(Inferencer):
         task: str | None = None,
         config: dict | None = None,
     ) -> None:
+        try:
+            import openvino as ov
+        except ImportError:
+            logger.warning("OpenVINO is not installed. Please install OpenVINO to use OpenVINOInferencer.")
+            raise
         self.device = device
 
         self.config = config
@@ -121,6 +118,8 @@ class OpenVINOInferencer(Inferencer):
             [tuple[str, str, ExecutableNetwork]]: Input and Output blob names
                 together with the Executable network.
         """
+        import openvino as ov
+
         core = ov.Core()
         # If tuple of bytes is passed
         if isinstance(path, tuple):

--- a/src/anomalib/deploy/inferencers/openvino_inferencer.py
+++ b/src/anomalib/deploy/inferencers/openvino_inferencer.py
@@ -4,12 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from importlib.util import find_spec
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import cv2
 import numpy as np
+from lightning_utilities.core.imports import package_available
 from omegaconf import DictConfig
 from PIL import Image
 
@@ -94,11 +94,10 @@ class OpenVINOInferencer(Inferencer):
         task: str | None = None,
         config: dict | None = None,
     ) -> None:
-        try:
-            import openvino as ov
-        except ImportError:
-            logger.warning("OpenVINO is not installed. Please install OpenVINO to use OpenVINOInferencer.")
-            raise
+        if not package_available("openvino"):
+            msg = "OpenVINO is not installed. Please install OpenVINO to use OpenVINOInferencer."
+            raise ImportError(msg)
+
         self.device = device
 
         self.config = config
@@ -107,7 +106,7 @@ class OpenVINOInferencer(Inferencer):
 
         self.task = TaskType(task) if task else TaskType(self.metadata["task"])
 
-    def load_model(self, path: str | Path | tuple[bytes, bytes]) -> tuple[Any, Any, "CompiledModel"]:
+    def load_model(self, path: str | Path | tuple[bytes, bytes]) -> tuple[Any, Any, Any]:
         """Load the OpenVINO model.
 
         Args:


### PR DESCRIPTION
## 📝 Description

- This PR addresses an issue where importing the `OpenVINOInferencer` class would trigger a warning about OpenVINO not being installed, even when the class wasn't being used. The solution defers the OpenVINO import until the `OpenVINOInferencer` is actually instantiated.
- 🛠️ Fixes:
  - #2384 
  - #2140

## ✨ Changes
- Removed global import of OpenVINO
- Moved OpenVINO import inside the `__init__` method of `OpenVINOInferencer`
- Added an `ImportError` raise if OpenVINO is not installed when the class is instantiated

Select what type of change your PR is:

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
