### PR TITLE
Fix the bug in F1AdaptiveThreshold

### DIFF
--- a/src/anomalib/metrics/threshold/f1_adaptive_threshold.py
+++ b/src/anomalib/metrics/threshold/f1_adaptive_threshold.py
@@ -75,6 +75,11 @@ class F1AdaptiveThreshold(BinaryPrecisionRecallCurve, Threshold):
             # special case where recall is 1.0 even for the highest threshold.
             # In this case 'thresholds' will be scalar.
             self.value = thresholds
+        elif not any(1 in batch for batch in self.target):
+            # another special case where there are no anomalous image in the validation set.
+            # In this case, the adaptive threshold will take the value of the highest anomaly score observed in the
+            # normal validation images.
+            self.value = torch.max(thresholds)
         else:
             self.value = thresholds[torch.argmax(f1_score)]
         return self.value


### PR DESCRIPTION
This pull request fix the bug in F1AdaptiveThreshold where the lowest threshold value is selected in stead of the highest if there are no anomalous images in a validation set.