### PR TITLE
Fix the bug in F1AdaptiveThreshold which occurs only when there are no anomalous images in a validation set

### DIFF
--- a/src/anomalib/metrics/threshold/f1_adaptive_threshold.py
+++ b/src/anomalib/metrics/threshold/f1_adaptive_threshold.py
@@ -75,6 +75,11 @@ class F1AdaptiveThreshold(BinaryPrecisionRecallCurve, Threshold):
             # special case where recall is 1.0 even for the highest threshold.
             # In this case 'thresholds' will be scalar.
             self.value = thresholds
+        elif not any(1 in batch for batch in self.target):
+            # another special case where there are no anomalous image in the validation set.
+            # In this case, the adaptive threshold will take the value of the highest anomaly score observed in the
+            # normal validation images.
+            self.value = torch.max(thresholds)
         else:
             self.value = thresholds[torch.argmax(f1_score)]
         return self.value

--- a/tests/unit/metrics/test_adaptive_threshold.py
+++ b/tests/unit/metrics/test_adaptive_threshold.py
@@ -18,6 +18,8 @@ from anomalib.utils.normalization import NormalizationMethod
     [
         (torch.Tensor([0, 0, 0, 1, 1]), torch.Tensor([2.3, 1.6, 2.6, 7.9, 3.3]), 3.3),  # standard case
         (torch.Tensor([1, 0, 0, 0]), torch.Tensor([4, 3, 2, 1]), 4),  # 100% recall for all thresholds
+        (torch.Tensor([1, 1, 1, 1]), torch.Tensor([4, 3, 2, 1]), 1),  # use minimum value when all images are anomalous
+        (torch.Tensor([0, 0, 0, 0]), torch.Tensor([4, 3, 2, 1]), 4),  # use maximum value when all images are normal
     ],
 )
 def test_adaptive_threshold(labels: torch.Tensor, preds: torch.Tensor, target_threshold: int | float) -> None:


### PR DESCRIPTION
## 📝 Description

- Fix the bug in `F1AdaptiveThreshold` which occurs only when there are no anomalous images in a validation set
- 🛠️ Fixes #2433 

## ✨ Changes

Select what type of change your PR is:

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [x] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
