### PR TITLE
remove setup methods from base module

### DIFF
--- a/src/anomalib/models/components/base/anomalib_module.py
+++ b/src/anomalib/models/components/base/anomalib_module.py
@@ -50,7 +50,6 @@ from typing import Any
 import lightning.pytorch as pl
 import torch
 from lightning.pytorch import Callback
-from lightning.pytorch.trainer.states import TrainerFn
 from lightning.pytorch.utilities.types import STEP_OUTPUT
 from torch import nn
 from torchvision.transforms.v2 import Compose, Normalize, Resize
@@ -143,7 +142,6 @@ class AnomalibModule(ExportMixin, pl.LightningModule, ABC):
         self.visualizer = self._resolve_visualizer(visualizer)
 
         self._input_size: tuple[int, int] | None = None
-        self._is_setup = False
 
     @property
     def name(self) -> str:
@@ -153,33 +151,6 @@ class AnomalibModule(ExportMixin, pl.LightningModule, ABC):
             str: Name of the model class
         """
         return self.__class__.__name__
-
-    def setup(self, stage: str | None = None) -> None:
-        """Set up the model if not already done.
-
-        This method ensures the model is built by calling ``_setup()`` if needed.
-
-        Args:
-            stage (str | None, optional): Current stage of training.
-                Defaults to ``None``.
-        """
-        if getattr(self, "model", None) is None or not self._is_setup:
-            self._setup()
-            if isinstance(stage, TrainerFn):
-                # only set the flag if the stage is a TrainerFn, which means the
-                # setup has been called from a trainer
-                self._is_setup = True
-
-    def _setup(self) -> None:
-        """Set up the model architecture.
-
-        This method should be overridden by subclasses to build their model
-        architecture. It is called by ``setup()`` when the model needs to be
-        initialized.
-
-        This is useful when the model cannot be fully initialized in ``__init__``
-        because it requires data-dependent parameters.
-        """
 
     def configure_callbacks(self) -> Sequence[Callback] | Callback:
         """Configure callbacks for the model.

--- a/src/anomalib/models/image/winclip/lightning_model.py
+++ b/src/anomalib/models/image/winclip/lightning_model.py
@@ -125,8 +125,9 @@ class WinClip(AnomalibModule):
         self.class_name = class_name
         self.k_shot = k_shot
         self.few_shot_source = Path(few_shot_source) if few_shot_source else None
+        self.is_setup = False
 
-    def _setup(self) -> None:
+    def setup(self, stage: str) -> None:
         """Setup WinCLIP model.
 
         This method:
@@ -137,6 +138,10 @@ class WinClip(AnomalibModule):
         Note:
             This hook is called before the model is moved to the target device.
         """
+        del stage
+        if self.is_setup:
+            return
+
         # get class name
         self.class_name = self._get_class_name()
         ref_images = None
@@ -158,6 +163,7 @@ class WinClip(AnomalibModule):
 
         # call setup to initialize the model
         self.model.setup(self.class_name, ref_images)
+        self.is_setup = True
 
     def _get_class_name(self) -> str:
         """Get the class name used in the prompt ensemble.


### PR DESCRIPTION
## 📝 Description

- Quick PR to remove the `setup` and `_setup_` methods from the `AnomalibModule`. These methods are a leftover from v1, and no longer used in v2.

## ✨ Changes

Select what type of change your PR is:

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
