### PR TITLE
Fix pre_process method to convert NumPy array to PyTorch tensor

### DIFF
--- a/src/anomalib/deploy/inferencers/torch_inferencer.py
+++ b/src/anomalib/deploy/inferencers/torch_inferencer.py
@@ -206,10 +206,10 @@ class TorchInferencer(Inferencer):
         Returns:
             Tensor: pre-processed image.
         """
-        if len(image) == 3:
-            image = image.unsqueeze(0)
-
-        return image.to(self.device)
+        if image.ndim == 3: 
+            image = np.expand_dims(image, axis=0) # Add batch dimension 
+        image_tensor = torch.from_numpy(image) # Convert to PyTorch tensor 
+        return image_tensor.to(self.device) # Move to the specified device
 
     def forward(self, image: torch.Tensor) -> torch.Tensor:
         """Forward-Pass input tensor to the model.


### PR DESCRIPTION
## 📝 Description

This pull request fixes the `pre_process` method in the TorchInferencer to correctly handle NumPy arrays before performing PyTorch operations. The main changes include: 
- Adding a batch dimension to the input image if it has 3 dimensions. 
- Converting the NumPy array to a PyTorch tensor. 
- Moving the tensor to the specified device.

🛠️ Fixes #2452

## ✨ Changes

[ ] 🐞 Bug fix (non-breaking change which fixes an issue)

- Updated `pre_process` method to add a batch dimension using `np.expand_dims` if the input image has 3 dimensions. 
- Converted the input image from a NumPy array to a PyTorch tensor using `torch.from_numpy`. 
- Moved the tensor to the specified device using the `to` method.


## ✅ Checklist

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).
