### PR TITLE
Fix post processor for classification tasks

### DIFF
--- a/src/anomalib/post_processing/one_class.py
+++ b/src/anomalib/post_processing/one_class.py
@@ -102,9 +102,9 @@ class OneClassPostProcessor(PostProcessor):
             **kwargs: Arbitrary keyword arguments.
         """
         del trainer, pl_module, args, kwargs  # Unused arguments.
-        if outputs.pred_score is not None:
+        if outputs.pred_score is not None and outputs.gt_label is not None:
             self._image_threshold.update(outputs.pred_score, outputs.gt_label)
-        if outputs.anomaly_map is not None:
+        if outputs.anomaly_map is not None and outputs.gt_mask is not None:
             self._pixel_threshold.update(outputs.anomaly_map, outputs.gt_mask)
         if outputs.pred_score is not None:
             self._image_normalization_stats.update(outputs.pred_score)


### PR DESCRIPTION
## 📝 Description
For classification tasks without ground truth masks, the one class post processor fails on updating the threshold if the model produces an anomaly map while there is no ground truth mask. This PR fixes this

## ✨ Changes

Select what type of change your PR is:

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
