### PR TITLE
Fix latest torch and torchvision compatibility

### DIFF
--- a/src/anomalib/data/transforms/center_crop.py
+++ b/src/anomalib/data/transforms/center_crop.py
@@ -142,3 +142,17 @@ class ExportableCenterCrop(Transform):
         """
         del params
         return center_crop_image(inpt, output_size=self.size)
+
+    def transform(self, inpt: torch.Tensor, params: dict[str, Any]) -> torch.Tensor:
+        """Wrapper for self._transform.
+
+        This is to ensure compatibility with Torchvision 2.6+, where the `_transform` method was renamed to `transform`.
+
+        Args:
+            inpt (torch.Tensor): Input tensor to transform
+            params (dict[str, Any]): Transform parameters (unused)
+
+        Returns:
+            torch.Tensor: Center-cropped output tensor
+        """
+        return self._transform(inpt, params)

--- a/src/anomalib/deploy/inferencers/torch_inferencer.py
+++ b/src/anomalib/deploy/inferencers/torch_inferencer.py
@@ -129,7 +129,7 @@ class TorchInferencer:
             msg = f"Unknown PyTorch checkpoint format {path.suffix}. Make sure you save the PyTorch model."
             raise ValueError(msg)
 
-        return torch.load(path, map_location=self.device)
+        return torch.load(path, map_location=self.device, weights_only=False)
 
     def load_model(self, path: str | Path) -> nn.Module:
         """Load the PyTorch model.


### PR DESCRIPTION
## 📝 Description

This PR fixes two problems that emerge when upgrading to PyTorch 2.6 and Torchvision 0.21.

- Fixes a problem with model loading in the torch inferencer, leading to CI failures. The problem was caused by a breaking change in PyTorch 2.6, where the default value of `weights_only` param of `torch.load` was changed from `False` to `True`. See https://pytorch.org/docs/main/notes/serialization.html#torch-load-with-weights-only-true for more information.
- Note that we may need to revisit how we load models in the torch inferencer, because loading with `weights_only==False` may lead to arbitrary code execution.
- Fixes a problem caused by the internal renaming of `Transform._transform` to `Transform.transform` in Torchvision 0.21.

## ✨ Changes

Select what type of change your PR is:

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
