### PR TITLE
Add MVTec backward compatibility

### DIFF
--- a/src/anomalib/data/__init__.py
+++ b/src/anomalib/data/__init__.py
@@ -49,7 +49,7 @@ from .dataclasses import (
 # Datamodules
 from .datamodules.base import AnomalibDataModule
 from .datamodules.depth import DepthDataFormat, Folder3D, MVTec3D
-from .datamodules.image import BTech, Datumaro, Folder, ImageDataFormat, Kolektor, MVTecAD, Visa
+from .datamodules.image import BTech, Datumaro, Folder, ImageDataFormat, Kolektor, MVTec, MVTecAD, Visa
 from .datamodules.video import Avenue, ShanghaiTech, UCSDped, VideoDataFormat
 
 # Datasets
@@ -160,6 +160,7 @@ __all__ = [
     "ImageDataFormat",
     "Kolektor",
     "KolektorDataset",
+    "MVTec",  # Include MVTec for backward compatibility
     "MVTecAD",
     "MVTecADDataset",
     "Visa",

--- a/src/anomalib/data/datamodules/__init__.py
+++ b/src/anomalib/data/datamodules/__init__.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .depth import Folder3D, MVTec3D
-from .image import BTech, Datumaro, Folder, Kolektor, MVTec, Visa
+from .image import BTech, Datumaro, Folder, Kolektor, MVTec, MVTecAD, Visa
 from .video import Avenue, ShanghaiTech, UCSDped
 
 __all__ = [
@@ -14,10 +14,10 @@ __all__ = [
     "Datumaro",
     "Folder",
     "Kolektor",
+    "MVTec",  # Include MVTec for backward compatibility
     "MVTecAD",
     "Visa",
     "Avenue",
     "ShanghaiTech",
     "UCSDped",
-    "MVTec",
 ]


### PR DESCRIPTION
## 📝 Description

- After renaming `MVTec` to `MVTecAD`, the relative import path to import MVTec is broken. This PR reverts that functionality back for compatibility.

```python
# Before 
from anomalib.data import MVTec

# After PR#2557
from anomalib.data import MVTec # ❌ Broken
from anomalib.data import MVTecAD

# Now
from anomalib.data import MVTec    # ✅ Deprecated, but works
from anomalib.data import MVTecAD
```

## ✨ Changes

Select what type of change your PR is:

- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update

## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
