### PR TITLE
🐞 Fix model-specific transforms for DRÆM and DSR

### DIFF
--- a/src/anomalib/models/image/draem/lightning_model.py
+++ b/src/anomalib/models/image/draem/lightning_model.py
@@ -19,7 +19,7 @@ from typing import Any
 import torch
 from lightning.pytorch.utilities.types import STEP_OUTPUT
 from torch import nn
-from torchvision.transforms.v2 import Compose, Resize, Transform
+from torchvision.transforms.v2 import Compose, Resize
 
 from anomalib import LearningType
 from anomalib.data import Batch
@@ -217,23 +217,20 @@ class Draem(AnomalibModule):
         """
         return LearningType.ONE_CLASS
 
-    @staticmethod
-    def configure_transforms(image_size: tuple[int, int] | None = None) -> Transform:
-        """Configure default transforms for DRAEM.
+    @classmethod
+    def configure_pre_processor(cls, image_size: tuple[int, int] | None = None) -> PreProcessor:
+        """Configure default pre-processor for DRÆM.
 
         Note:
-            Normalization is not needed as images are scaled to [0, 1] in Dataset.
+            Imagenet normalization is not used in this model.
 
         Args:
-            image_size (tuple[int, int] | None, optional): Target size for image
-                resizing. Defaults to ``(256, 256)``.
+            image_size (tuple[int, int] | None, optional): Target image size.
+                Defaults to ``(256, 256)``.
 
         Returns:
-            Transform: Composed transform including resizing.
+            PreProcessor: Configured pre-processor with resize transform.
         """
         image_size = image_size or (256, 256)
-        return Compose(
-            [
-                Resize(image_size, antialias=True),
-            ],
-        )
+        transform = Compose([Resize(image_size, antialias=True)])
+        return PreProcessor(transform=transform)

--- a/src/anomalib/models/image/dsr/lightning_model.py
+++ b/src/anomalib/models/image/dsr/lightning_model.py
@@ -39,7 +39,7 @@ from typing import Any
 
 import torch
 from lightning.pytorch.utilities.types import STEP_OUTPUT, OptimizerLRScheduler
-from torchvision.transforms.v2 import Compose, Resize, Transform
+from torchvision.transforms.v2 import Compose, Resize
 
 from anomalib import LearningType
 from anomalib.data import Batch
@@ -319,28 +319,20 @@ class Dsr(AnomalibModule):
         """
         return LearningType.ONE_CLASS
 
-    @staticmethod
-    def configure_transforms(image_size: tuple[int, int] | None = None) -> Transform:
-        """Configure default transforms for DSR.
+    @classmethod
+    def configure_pre_processor(cls, image_size: tuple[int, int] | None = None) -> PreProcessor:
+        """Configure default pre-processor for DSR.
 
-        Normalization is not needed as the images are scaled to [0, 1] in Dataset.
+        Note:
+            Imagenet normalization is not used in this model.
 
         Args:
-            image_size (tuple[int, int] | None, optional): Input image size.
+            image_size (tuple[int, int] | None, optional): Target image size.
                 Defaults to ``(256, 256)``.
 
         Returns:
-            Transform: Composed transforms
-
-        Example:
-            >>> model = Dsr()
-            >>> transforms = model.configure_transforms((512, 512))
-            >>> isinstance(transforms, Transform)
-            True
+            PreProcessor: Configured pre-processor with resize transform.
         """
         image_size = image_size or (256, 256)
-        return Compose(
-            [
-                Resize(image_size, antialias=True),
-            ],
-        )
+        transform = Compose([Resize(image_size, antialias=True)])
+        return PreProcessor(transform=transform)


### PR DESCRIPTION
## 📝 Description

These models do not use Imagenet normalization. They had `configure_transforms()` to handle it, but it is never called, so default transforms with Imagenet normalization are applied. The training code is below, printing image values show that they are not between 0 and 1, as they should be.

```
from anomalib.data import MVTecAD
from anomalib.models import Draem
from anomalib.engine import Engine

# Initialize components
datamodule = MVTecAD()
model = Draem()
engine = Engine()

# Train the model
engine.fit(datamodule=datamodule, model=model)
```


## ✨ Changes
This PR changes `configure_transforms()` in DRÆM and DSR to `configure_pre_processor()` to apply model-specific transforms properly.

Select what type of change your PR is:

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🔨 Refactor (non-breaking change which refactors the code base)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔒 Security update



## ✅ Checklist

Before you submit your pull request, please make sure you have completed the following steps:

- [ ] 📋 I have summarized my changes in the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) and followed the guidelines for my type of change (skip for minor changes, documentation updates, and test enhancements).
- [ ] 📚 I have made the necessary updates to the documentation (if applicable).
- [ ] 🧪 I have written tests that support my changes and prove that my fix is effective or my feature works (if applicable).

For more information about code review checklists, see the [Code Review Checklist](https://github.com/openvinotoolkit/anomalib/blob/main/docs/source/markdown/guides/developer/code_review_checklist.md).
